### PR TITLE
Fix autodrain:

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -61,7 +61,11 @@ Parse.prototype._readFile = function () {
     return this.pull(vars.fileNameLength).then(fileName => {
       fileName = fileName.toString('utf8');
       var entry = Stream.PassThrough();
-      entry.autodrain = () => this.pipe(noopStream());
+      entry.autodrain = () => new Promise( (resolve,reject) => {
+        entry.pipe(noopStream());
+        entry.on('finish',resolve);
+        entry.on('error',reject);
+      });
       entry.path = fileName;
       entry.props = {};
       entry.props.path = fileName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [


### PR DESCRIPTION
The source stream should be `entry` not `this`
Also return a promise upon `finish` or `error`