### PR TITLE
Add `.buffer` to `entry`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,5 +103,22 @@ fs.createReadStream('path/to/archive.zip')
   .pipe(fs.createReadStream('firstFile.txt'));
 ```
 
+### Buffering the content of an entry into memory
+
+While the recommended strategy of consuming the unzipped contents is using streams, it is sometimes convenient to be able to get the full buffered contents of each file .  Each `entry` provides a `.buffer` function that consumes the entry by buffering the contents into memory and returning a promise to the complete buffer.  
+
+```js
+fs.createReadStream('path/to/archive.zip')
+  .pipe(unzipper.Parse())
+  .pipe(etl.map(entry => {
+    if (entry.path == "this IS the file I'm looking for")
+      entry
+        .buffer()
+        .then(content => fs.writeFile('output/path',content))
+    else
+      entry.autodrain();
+  }))
+
+
 ## Licenses
 See LICENCE

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -72,6 +72,7 @@ Parse.prototype._readFile = function () {
     return self.pull(vars.fileNameLength).then(function(fileName) {
       fileName = fileName.toString('utf8');
       var entry = Stream.PassThrough();
+      
       entry.autodrain = function() {
         return new Promise(function(resolve,reject) {
           entry.pipe(NoopStream());
@@ -79,6 +80,24 @@ Parse.prototype._readFile = function () {
           entry.on('error',reject);
         });
       };
+
+      entry.buffer = function() {
+        return new Promise(function(resolve,reject) {
+          var buffer = new Buffer(''),
+              bufferStream = Stream.Transform()
+                .on('finish',function() {
+                  resolve(buffer);
+                })
+                .on('error',reject);
+              
+          bufferStream._transform = function(d,e,cb) {
+            buffer = Buffer.concat([buffer,d]);
+            cb();
+          };
+          entry.pipe(bufferStream);
+        });
+      };
+
       entry.path = fileName;
       entry.props = {};
       entry.props.path = fileName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [

--- a/test/parseContent.js
+++ b/test/parseContent.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var test = require('tap').test;
+var fs = require('fs');
+var path = require('path');
+var temp = require('temp');
+var streamBuffers = require("stream-buffers");
+var unzip = require('../');
+
+test("get content of a single file entry out of a zip", function (t) {
+  var archive = path.join(__dirname, '../testData/compressed-standard/archive.zip');
+
+  fs.createReadStream(archive)
+    .pipe(unzip.Parse())
+    .on('entry', function(entry) {
+      if (entry.path !== 'file.txt')
+        return entry.autodrain();
+
+      entry.buffer()
+        .then(function(str) {
+          var fileStr = fs.readFileSync(path.join(__dirname, '../testData/compressed-standard/inflated/file.txt'), 'utf8');
+          t.equal(str.toString(), fileStr);
+          t.end();
+        });
+    });
+});


### PR DESCRIPTION
While the recommended strategy of consuming the unzipped contents is using streams, it is sometimes convenient to be able to get the full buffered contents of each file .  Each `entry` provides a `.buffer` function that consumes the entry by buffering the contents into memory and returning a promise to the complete buffer.  
