### PR TITLE
Better handling of EOF

### DIFF
--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -13,6 +13,11 @@ function PullStream() {
 
   Stream.Duplex.call(this,{decodeStrings:false, objectMode:true});
   this.buffer = new Buffer(''); 
+  var self = this;
+  self.on('finish',function() {
+    self.finished = true;
+    self.emit('chunk',false);
+  });
 }
 
 util.inherits(PullStream,Stream.Duplex);
@@ -70,11 +75,11 @@ PullStream.prototype.stream = function(eof,includeEof) {
     }
     
     if (!done) {
-      if (self.flushcb) {
+      if (self.finished) {
         self.removeListener('chunk',pull);
-        self.emit('error','FILE_ENDED');
         p.emit('error','FILE_ENDED');
         this.__ended = true;
+        return;
       }
       self.next();
     } else {
@@ -101,7 +106,10 @@ PullStream.prototype.pull = function(eof,includeEof) {
   };
   
   return new Promise(function(resolve,reject) {
+    if (self.finished)
+      return reject('FILE_ENDED');
     self.stream(eof,includeEof)
+      .on('error',reject)
       .pipe(concatStream)
       .on('finish',function() {resolve(buffer);})
       .on('error',reject);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [


### PR DESCRIPTION
When the main stream finishes we register `finish` and emit a `chunk` to ensure any outstanding pipes gets closed out.  Also prevent new pipes from a closed stream.