### PR TITLE
Emit error if parseOne fails to find a matching file

### DIFF
--- a/lib/parseOne.js
+++ b/lib/parseOne.js
@@ -32,7 +32,10 @@ function parseOne(match) {
   inStream.pipe(Parse())
     .pipe(transform)
     .on('finish',function() {
-      outStream.end();
+      if (!found)
+        outStream.emit('error',new Error('PATTERN_NOT_FOUND'));
+      else
+        outStream.end();
     });
 
   return duplexer2(inStream,outStream);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [

--- a/test/parseOneEntry.js
+++ b/test/parseOneEntry.js
@@ -12,6 +12,8 @@ var Stream = require('stream');
 if (!Stream.Writable)
   Stream = require('readable-stream');
 
+var archive = path.join(__dirname, '../testData/compressed-standard/archive.zip');
+
 test("pipe a single file entry out of a zip", function (t) {
   var writableStream = new streamBuffers.WritableStreamBuffer();
   writableStream.on('close', function () {
@@ -21,9 +23,16 @@ test("pipe a single file entry out of a zip", function (t) {
     t.end();
   });
 
-  var archive = path.join(__dirname, '../testData/compressed-standard/archive.zip');
-
   fs.createReadStream(archive)
     .pipe(unzip.ParseOne('file.txt'))
     .pipe(writableStream);
+});
+
+test('errors if file is not found', function (t) {
+  fs.createReadStream(archive)
+    .pipe(unzip.ParseOne('not_exists'))
+    .on('error',function(e) {
+      t.equal(e.message,'PATTERN_NOT_FOUND');
+      t.end();
+    });
 });


### PR DESCRIPTION
An example in issue https://github.com/ZJONSSON/node-unzipper/issues/15 should have thrown an error instead of silently creating an empty file.