### PR TITLE
Add: Open.file and Open.url

### DIFF
--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -1,0 +1,82 @@
+var binary = require('binary');
+var PullStream = require('../PullStream');
+var unzip = require('./unzip');
+var Promise = require('bluebird');
+var BufferStream = require('../BufferStream');
+
+var signature = Buffer(4);
+signature.writeUInt32LE(0x06054b50,0);
+
+module.exports = function centralDirectory(source) {
+  var endDir = PullStream(),
+      records = PullStream(),
+      self = this,
+      vars;
+
+  return source.size()
+    .then(function(size) {
+      source.stream(size-40).pipe(endDir);
+      return endDir.pull(signature);
+    })
+    .then(function() {
+      return endDir.pull(22);
+    })
+    .then(function(data) {
+      vars = binary.parse(data)
+        .word32lu('signature')
+        .word16lu('diskNumber')
+        .word16lu('diskStart')
+        .word16lu('numberOfRecordsOnDisk')
+        .word16lu('numberOfRecords')
+        .word32lu('sizeOfCentralDirectory')
+        .word32lu('offsetToStartOfCentralDirectory')
+        .word16lu('commentLength')
+        .vars;
+
+      source.stream(vars.offsetToStartOfCentralDirectory).pipe(records);
+
+      vars.files = Promise.mapSeries(Array(vars.numberOfRecords),function() {
+        return records.pull(46).then(function(data) {    
+          var vars = binary.parse(data)
+            .word32lu('signature')
+            .word16lu('versionMadeBy')
+            .word16lu('versionsNeededToExtract')
+            .word16lu('flags')
+            .word16lu('compressionMethod')
+            .word16lu('lastModifiedTime')
+            .word16lu('lastModifiedDate')
+            .word32lu('crc32')
+            .word32lu('compressedSize')
+            .word32lu('uncompressedSize')
+            .word16lu('fileNameLength')
+            .word16lu('extraFieldLength')
+            .word16lu('fileCommentLength')
+            .word16lu('diskNumber')
+            .word16lu('internalFileAttributes')
+            .word32lu('externalFileAttributes')
+            .word32lu('offsetToLocalFileHeader')
+            .vars;
+
+        return records.pull(vars.fileNameLength).then(function(fileName) {
+          vars.path = fileName.toString('utf8');
+          return records.pull(vars.extraFieldLength);
+        })
+        .then(function(extraField) {
+          return records.pull(vars.fileCommentLength);
+        })
+        .then(function(comment) {
+          vars.comment = comment;
+          vars.stream = function() {
+            return unzip(source, vars.offsetToLocalFileHeader);
+          };
+          vars.buffer = function() {
+            return BufferStream(vars.stream());
+          };
+          return vars;
+        });
+      });
+    });
+
+    return Promise.props(vars);
+  });
+};

--- a/lib/Open/index.js
+++ b/lib/Open/index.js
@@ -1,0 +1,53 @@
+var fs = require('fs');
+var Promise = require('bluebird');
+var directory = require('./directory');
+
+module.exports = {
+  file: function(filename) {
+    var source = {
+      stream: function(offset,length) {
+        return fs.createReadStream(filename,{start: offset, end: length && offset+length});
+      },
+      size: function() {
+        return new Promise(function(resolve,reject) {
+          fs.stat(filename,function(err,d) {
+            if (err)
+              reject(err);
+            else
+              resolve(d.size);
+          });
+        });
+      }
+    };
+    return directory(source);
+  },
+
+  url: function(request,opt) {
+    if (typeof opt === 'string')
+      opt = {url: opt};
+    if (!opt.url)
+      throw 'URL missing';
+    opt.headers = opt.headers || {};
+
+    var source = {
+      stream : function(offset,length) {
+        var options = Object.create(opt);
+        options.headers = Object.create(opt.headers);
+        options.headers.range = 'bytes='+offset+'-' + (length ? length : '');
+        return request(options);
+      },
+      size: function() {
+        return new Promise(function(resolve,reject) {
+          var req = request(opt);
+          req.on('response',function(d) {
+            req.abort();
+            resolve(d.headers['content-length']);
+          }).on('error',reject);
+        });
+      }
+    };
+
+    return directory(source);
+  }
+};
+

--- a/lib/Open/unzip.js
+++ b/lib/Open/unzip.js
@@ -1,0 +1,93 @@
+var PullStream = require('../PullStream');
+var Stream = require('stream');
+var binary = require('binary');
+var zlib = require('zlib');
+
+// Backwards compatibility for node 0.8
+if (!Stream.Writable)
+  Stream = require('readable-stream');
+
+module.exports = function unzip(source,offset) {
+  var file = PullStream(),
+      entry = Stream.PassThrough(),
+      vars;
+
+  var req = source.stream(offset);
+  req.pipe(file);
+
+  entry.vars = file.pull(30)
+    .then(function(data) {
+      var vars = binary.parse(data)
+        .word32lu('signature')
+        .word16lu('versionsNeededToExtract')
+        .word16lu('flags')
+        .word16lu('compressionMethod')
+        .word16lu('lastModifiedTime')
+        .word16lu('lastModifiedDate')
+        .word32lu('crc32')
+        .word32lu('compressedSize')
+        .word32lu('uncompressedSize')
+        .word16lu('fileNameLength')
+        .word16lu('extraFieldLength')
+        .vars;
+      return file.pull(vars.fileNameLength)    
+        .then(function(fileName) {
+          vars.fileName = fileName.toString('utf8');
+          return file.pull(vars.extraFieldLength);
+        })
+        .then(function(extraField) {
+          var extra = binary.parse(extraField)
+            .word16lu('signature')
+            .word16lu('partsize')
+            .word64lu('uncompressedSize')
+            .word64lu('compressedSize')
+            .word64lu('offset')
+            .word64lu('disknum')
+            .vars;
+         
+          if (vars.compressedSize === 0xffffffff)
+            vars.compressedSize = extra.compressedSize;
+          
+          if (vars.uncompressedSize  === 0xffffffff)
+            vars.uncompressedSize= extra.uncompressedSize;
+
+          entry.emit('vars',vars);
+          return vars;
+        });
+    });
+
+    entry.vars.then(function(vars) {
+      var fileSizeKnown = !(vars.flags & 0x08),
+          eof;
+
+      var inflater = vars.compressionMethod ? zlib.createInflateRaw() : Stream.PassThrough();
+
+      if (fileSizeKnown) {
+        entry.size = vars.uncompressedSize;
+        eof = vars.compressedSize;
+      } else {
+        eof = new Buffer(4);
+        eof.writeUInt32LE(0x08074b50, 0);
+      }
+
+      file.stream(eof)
+        .pipe(inflater)
+        .on('error',function(err) { entry.emit('error',err);})
+        .pipe(entry)
+        .on('finish', function() {
+          if (req.abort)
+            req.abort();
+          else if (req.close)
+            req.close();
+          else if (req.push)
+            req.push();
+          else
+            console.log('warning - unable to close stream');
+        });
+    })
+    .catch(function(e) {
+      entry.emit('error',e);
+    });
+
+  return entry;       
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [
@@ -33,6 +33,7 @@
     "setimmediate": "~1.0.4"
   },
   "devDependencies": {
+    "request": "^2.79.0",
     "tap": ">= 0.3.0 < 1",
     "temp": ">= 0.4.0 < 1",
     "dirdiff": ">= 0.0.1 < 1",

--- a/test/openFile.js
+++ b/test/openFile.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var test = require('tap').test;
+var fs = require('fs');
+var path = require('path');
+var unzip = require('../');
+
+test("get content of a single file entry out of a zip", function (t) {
+  var archive = path.join(__dirname, '../testData/compressed-standard/archive.zip');
+
+  return unzip.Open.file(archive)
+    .then(function(d) {
+      var file = d.files.filter(function(file) {
+        return file.path == 'file.txt';
+      })[0];
+
+      return file.buffer()
+        .then(function(str) {
+          var fileStr = fs.readFileSync(path.join(__dirname, '../testData/compressed-standard/inflated/file.txt'), 'utf8');
+          t.equal(str.toString(), fileStr);
+          t.end();
+        });
+    });
+});

--- a/test/openUrl.js
+++ b/test/openUrl.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var test = require('tap').test;
+var fs = require('fs');
+var path = require('path');
+var unzip = require('../');
+var request = require('request');
+
+test("get content of a single file entry out of a 502 MB zip from web", function (t) {
+  return unzip.Open.url(request,'http://www2.census.gov/geo/tiger/TIGER2015/ZCTA5/tl_2015_us_zcta510.zip')
+    .then(function(d) {
+      var file = d.files.filter(function(d) {
+        return d.path === 'tl_2015_us_zcta510.shp.iso.xml';
+      })[0];
+      return file.buffer();
+    })
+    .then(function(str) {
+       var fileStr = fs.readFileSync(path.join(__dirname, '../testData/tl_2015_us_zcta510.shp.iso.xml'), 'utf8');
+      t.equal(str.toString(), fileStr);
+      t.end();
+    });
+});

--- a/testData/tl_2015_us_zcta510.shp.iso.xml
+++ b/testData/tl_2015_us_zcta510.shp.iso.xml
@@ -1,0 +1,519 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<gmi:MI_Metadata xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:gmi="http://www.isotc211.org/2005/gmi">
+   <gmd:fileIdentifier>
+      <gco:CharacterString>tl_2015_us_zcta510.shp.iso.xml</gco:CharacterString>
+   </gmd:fileIdentifier>
+   <gmd:language>
+      <gco:CharacterString>eng</gco:CharacterString>
+   </gmd:language>
+   <gmd:characterSet>
+      <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode"
+                               codeListValue="8859part1"
+                               codeSpace="006">8859part1</gmd:MD_CharacterSetCode>
+   </gmd:characterSet>
+   <gmd:hierarchyLevel>
+      <gmd:MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode"
+                        codeListValue="dataset">
+dataset
+</gmd:MD_ScopeCode>
+   </gmd:hierarchyLevel>
+   <gmd:contact xlink:href="https://www.ngdc.noaa.gov/docucomp/c5ceb003-1ed6-4126-8a16-bc08ce8fc267"
+                xlink:title="U.S. Department of Commerce, U.S. Census Bureau, Geography Division, Geographic Products Branch"/>
+   <gmd:dateStamp>
+      <gco:Date>2015-06-01</gco:Date>
+   </gmd:dateStamp>
+   <gmd:metadataStandardName>
+      <gco:CharacterString>ISO 19115 Geographic Information - Metadata </gco:CharacterString>
+   </gmd:metadataStandardName>
+   <gmd:metadataStandardVersion>
+      <gco:CharacterString>2009-02-15 </gco:CharacterString>
+   </gmd:metadataStandardVersion>
+   <gmd:dataSetURI>
+      <gco:CharacterString>http://www2.census.gov/geo/tiger/TIGER2015/ZCTA510</gco:CharacterString>
+   </gmd:dataSetURI>
+   <!-- This is the ptvctinf/sdtsterm/sdtstype from section 3 of the FGDC Standard (Spatial Data Organization) -->
+<gmd:spatialRepresentationInfo>
+      <gmd:MD_VectorSpatialRepresentation>
+         <gmd:geometricObjects>
+            <gmd:MD_GeometricObjects>
+               <gmd:geometricObjectType>
+                  <gmd:MD_GeometricObjectTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_GeometricObjectTypeCode"
+                                                  codeListValue="complex"
+                                                  codeSpace="001">
+                                                complex </gmd:MD_GeometricObjectTypeCode>
+               </gmd:geometricObjectType>
+               <gmd:geometricObjectCount>
+                  <gco:Integer>33144</gco:Integer>
+               </gmd:geometricObjectCount>
+            </gmd:MD_GeometricObjects>
+         </gmd:geometricObjects>
+      </gmd:MD_VectorSpatialRepresentation>
+   </gmd:spatialRepresentationInfo>
+   <!--This is the indirect spatial reference of section 3 of the FGDC Standard-->
+<gmd:referenceSystemInfo>
+      <gmd:MD_ReferenceSystem>
+         <gmd:referenceSystemIdentifier>
+            <gmd:RS_Identifier>
+               <gmd:code gco:nilReason="unknown"/>
+               <gmd:codeSpace>
+                  <gco:CharacterString>Federal Information Processing Series (FIPS), Geographic Names Information System (GNIS), and feature names.</gco:CharacterString>
+               </gmd:codeSpace>
+            </gmd:RS_Identifier>
+         </gmd:referenceSystemIdentifier>
+      </gmd:MD_ReferenceSystem>
+   </gmd:referenceSystemInfo>
+   <!-- This part represents Section 1 of the FGDC Metadata Standard -->
+<gmd:identificationInfo>
+      <gmd:MD_DataIdentification>
+         <gmd:citation>
+            <gmd:CI_Citation>
+               <gmd:title>
+                  <gco:CharacterString>TIGER/Line Shapefile, 2015, 2010 nation, U.S., 2010 Census 5-Digit ZIP Code Tabulation Area (ZCTA5) National</gco:CharacterString>
+               </gmd:title>
+               <gmd:date>
+                  <gmd:CI_Date>
+<!-- This is the publication date -->
+<gmd:date>
+                        <gco:Date>2015</gco:Date>
+                     </gmd:date>
+                     <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                             codeListValue="publication"
+                                             codeSpace="002"> publication </gmd:CI_DateTypeCode>
+                     </gmd:dateType>
+                  </gmd:CI_Date>
+               </gmd:date>
+               <gmd:edition>
+                  <gco:CharacterString>2015</gco:CharacterString>
+               </gmd:edition>
+               <gmd:citedResponsibleParty xlink:href="https://www.ngdc.noaa.gov/docucomp/cf2b3bf2-5dd9-4fed-a495-1ddfb9a41de2 "
+                                          xlink:title="U.S. Department of Commerce, U.S. Census Bureau, Geography Division (Originator) "/>
+            </gmd:CI_Citation>
+         </gmd:citation>
+         <gmd:abstract>
+            <gco:CharacterString>The TIGER/Line shapefiles and related database files (.dbf) are an extract of selected geographic and cartographic information from the U.S. Census Bureau's Master Address File / Topologically Integrated Geographic Encoding and Referencing (MAF/TIGER) Database (MTDB).  The MTDB represents a seamless national file with no overlaps or gaps between parts, however, each TIGER/Line shapefile is designed to stand alone as an independent data set, or they can be combined to cover the entire nation.
+
+
+ZIP Code Tabulation Areas (ZCTAs) are approximate area representations of U.S. Postal Service (USPS) ZIP Code service areas that the Census Bureau creates to present statistical data for each decennial census. The Census Bureau delineates ZCTA boundaries for the United States, Puerto Rico, American Samoa, Guam, the Commonwealth of the Northern Mariana Islands, and the U.S. Virgin Islands once each decade following the decennial census. Data users should not use ZCTAs to identify the official USPS ZIP Code for mail delivery. The USPS makes periodic changes to ZIP Codes to support more efficient mail delivery.
+
+
+The Census Bureau uses tabulation blocks as the basis for defining each ZCTA. Tabulation blocks are assigned to a ZCTA based on the most frequently occurring ZIP Code for the addresses contained within that block. The most frequently occurring ZIP Code also becomes the five-digit numeric code of the ZCTA. These codes may contain leading zeros.
+
+
+Blocks that do not contain addresses but are surrounded by a single ZCTA (enclaves) are assigned to the surrounding ZCTA. Because the Census Bureau only uses the most frequently occurring ZIP Code to assign blocks, a ZCTA may not exist for every USPS ZIP Code. Some ZIP Codes may not have a matching ZCTA because too few addresses were associated with the specific ZIP Code or the ZIP Code was not the most frequently occurring ZIP Code within any of the blocks where it exists. 
+
+
+The ZCTA boundaries in this release are those delineated following the 2010 Census. 
+</gco:CharacterString>
+         </gmd:abstract>
+         <gmd:purpose>
+            <gco:CharacterString>In order for others to use the information in the Census MAF/TIGER database in a geographic information system (GIS) or for other geographic applications, the Census Bureau releases to the public extracts of the database in the form of TIGER/Line Shapefiles.</gco:CharacterString>
+         </gmd:purpose>
+         <gmd:status>
+            <gmd:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode"
+                                 codeListValue="completed">
+                        completed
+                    </gmd:MD_ProgressCode>
+         </gmd:status>
+         <gmd:pointOfContact xlink:href="https://www.ngdc.noaa.gov/docucomp/09b8253a-e2dc-4a6b-a905-11f1e0e87b3b"
+                             xlink:title="pointOfContact - U.S. Department of Commerce, U.S. Census Bureau, Geography Division"/>
+         <gmd:resourceMaintenance>
+            <gmd:MD_MaintenanceInformation>
+               <gmd:maintenanceAndUpdateFrequency>
+                  <gmd:MD_MaintenanceFrequencyCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode"
+                                                   codeListValue="notPlanned"
+                                                   codeSpace="011">
+                         notPlanned
+                </gmd:MD_MaintenanceFrequencyCode>
+               </gmd:maintenanceAndUpdateFrequency>
+            </gmd:MD_MaintenanceInformation>
+         </gmd:resourceMaintenance>
+         <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+               <gmd:keyword>
+                  <gco:CharacterString>NGDA</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>Governmental Units and Administrative and Statistical Boundaries Theme</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>National Geospatial Data Asset</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:type>
+                  <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode"
+                                          codeListValue="theme"
+                                          codeSpace="005"> theme </gmd:MD_KeywordTypeCode>
+               </gmd:type>
+               <gmd:thesaurusName>
+                  <gmd:CI_Citation>
+                     <gmd:title>
+                        <gco:CharacterString>NGDA Portfolio Themes</gco:CharacterString>
+                     </gmd:title>
+                     <gmd:date>
+                        <gmd:CI_Date>
+                           <gmd:date>
+                              <gco:Date>2010-02-01</gco:Date>
+                           </gmd:date>
+                           <gmd:dateType>
+                              <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                                   codeListValue="revision"
+                                                   codeSpace="003"> revision
+                            </gmd:CI_DateTypeCode>
+                           </gmd:dateType>
+                        </gmd:CI_Date>
+                     </gmd:date>
+                     <gmd:otherCitationDetails>
+                        <gco:CharacterString>http://www.fgdc.gov/initiatives/resources/2013-2-1-ngda-data-themes-fgdc-sc-revised.pdf</gco:CharacterString>
+                     </gmd:otherCitationDetails>
+                  </gmd:CI_Citation>
+               </gmd:thesaurusName>
+            </gmd:MD_Keywords>
+         </gmd:descriptiveKeywords>
+         <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+               <gmd:keyword>
+                  <gco:CharacterString>Nation</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>Polygon</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>ZIP Code Tabulation Area</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>ZCTA</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>Zip Code</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:type>
+                  <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode"
+                                          codeListValue="theme"
+                                          codeSpace="005"> theme </gmd:MD_KeywordTypeCode>
+               </gmd:type>
+               <gmd:thesaurusName>
+                  <gmd:CI_Citation>
+                     <gmd:title>
+                        <gco:CharacterString>None</gco:CharacterString>
+                     </gmd:title>
+                     <gmd:date gco:nilReason="unknown"/>
+                  </gmd:CI_Citation>
+               </gmd:thesaurusName>
+            </gmd:MD_Keywords>
+         </gmd:descriptiveKeywords>
+         <gmd:descriptiveKeywords>
+            <gmd:MD_Keywords>
+               <gmd:keyword>
+                  <gco:CharacterString>United States</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:keyword>
+                  <gco:CharacterString>U.S.</gco:CharacterString>
+               </gmd:keyword>
+               <gmd:type>
+                  <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode"
+                                          codeListValue="place"
+                                          codeSpace="002"> place </gmd:MD_KeywordTypeCode>
+               </gmd:type>
+               <gmd:thesaurusName>
+                  <gmd:CI_Citation>
+                     <gmd:title>
+                        <gco:CharacterString>ANSI INCITS 38:2009 (Formerly FIPS 5-2), ANSI INCITS 31:2009 (Formerly FIPS 6-4),ANSI INCITS 454:2009 (Formerly FIPS 8-6), ANSI INCITS 455:2009(Formerly FIPS 9-1), ANSI INCITS 446:2008 (Geographic Names Information System (GNIS))</gco:CharacterString>
+                     </gmd:title>
+                     <gmd:date gco:nilReason="unknown"/>
+                  </gmd:CI_Citation>
+               </gmd:thesaurusName>
+            </gmd:MD_Keywords>
+         </gmd:descriptiveKeywords>
+         <gmd:resourceConstraints>
+            <gmd:MD_LegalConstraints>
+               <gmd:accessConstraints>
+                  <gmd:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode"
+                                          codeListValue="otherRestrictions"
+                                          codeSpace="008 "> otherRestrictions </gmd:MD_RestrictionCode>
+               </gmd:accessConstraints>
+               <gmd:useConstraints>
+                  <gmd:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode"
+                                          codeListValue="otherRestrictions"
+                                          codeSpace="008 "/>
+               </gmd:useConstraints>
+               <gmd:otherConstraints>
+                  <gco:CharacterString> Access Constraints: None</gco:CharacterString>
+               </gmd:otherConstraints>
+               <gmd:otherConstraints>
+                  <gco:CharacterString> Use Constraints:The TIGER/Line Shapefile products are not copyrighted however TIGER/Line and Census TIGER are registered trademarks of the U.S. Census Bureau.  These products are free to use in a product or publication, however acknowledgement must be given to the U.S. Census Bureau as the source.
+The boundary information in the TIGER/Line Shapefiles are for statistical data collection and tabulation purposes only; their depiction and designation for statistical purposes does not constitute a determination of jurisdictional authority or rights of ownership or entitlement and they are not legal land descriptions.Coordinates in the TIGER/Line shapefiles have six implied decimal places, but the positional accuracy of these coordinates is not as great as the six decimal places suggest.</gco:CharacterString>
+               </gmd:otherConstraints>
+            </gmd:MD_LegalConstraints>
+         </gmd:resourceConstraints>
+            <!-- This is from the Direct Spatial Reference from Chapter 3 -->
+            <gmd:spatialRepresentationType>
+            <gmd:MD_SpatialRepresentationTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_SpatialRepresentationTypeCode"
+                                                  codeListValue="vector">vector</gmd:MD_SpatialRepresentationTypeCode>
+         </gmd:spatialRepresentationType>
+         <gmd:language>
+            <gco:CharacterString>eng</gco:CharacterString>
+         </gmd:language>
+         <gmd:characterSet>
+            <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode"
+                                     codeListValue="8859part1"
+                                     codeSpace="006">8859part1</gmd:MD_CharacterSetCode>
+         </gmd:characterSet>
+         <gmd:topicCategory>
+            <gmd:MD_TopicCategoryCode>boundaries</gmd:MD_TopicCategoryCode>
+         </gmd:topicCategory>
+         <gmd:environmentDescription>
+            <gco:CharacterString>The TIGER/Line shapefiles contain geographic data only and do not include display mapping software or statistical data.  For information on how to use the TIGER/Line shapefile data with specific software package users shall contact the company that produced the software.</gco:CharacterString>
+         </gmd:environmentDescription>
+         <gmd:extent>
+            <gmd:EX_Extent id="boundingExtent">
+               <gmd:geographicElement>
+                  <gmd:EX_GeographicBoundingBox id="boundingGeographicBoundingBox">
+                     <gmd:westBoundLongitude>
+                        <gco:Decimal>-179.231086</gco:Decimal>
+                     </gmd:westBoundLongitude>
+                     <gmd:eastBoundLongitude>
+                        <gco:Decimal>179.859681</gco:Decimal>
+                     </gmd:eastBoundLongitude>
+                     <gmd:southBoundLatitude>
+                        <gco:Decimal>-14.601813</gco:Decimal>
+                     </gmd:southBoundLatitude>
+                     <gmd:northBoundLatitude>
+                        <gco:Decimal>71.441059</gco:Decimal>
+                     </gmd:northBoundLatitude>
+                  </gmd:EX_GeographicBoundingBox>
+               </gmd:geographicElement>
+               <gmd:temporalElement>
+                  <gmd:EX_TemporalExtent id="boundingTemporalExtent">
+                     <gmd:extent>
+                        <gml:TimePeriod gml:id="boundingTemporalExtentA">
+                           <gml:description>Publication Date</gml:description>
+                           <gml:beginPosition>2014-06</gml:beginPosition>
+                           <gml:endPosition>2015-05</gml:endPosition>
+                        </gml:TimePeriod>
+                     </gmd:extent>
+                  </gmd:EX_TemporalExtent>
+               </gmd:temporalElement>
+            </gmd:EX_Extent>
+         </gmd:extent>
+      </gmd:MD_DataIdentification>
+   </gmd:identificationInfo>
+   <!--This section provides the link for the file containing the Entity and Attribute Information. -->
+<gmd:contentInfo>
+      <gmd:MD_FeatureCatalogueDescription>
+         <gmd:includedWithDataset>
+            <gco:Boolean>true</gco:Boolean>
+         </gmd:includedWithDataset>
+         <gmd:featureTypes>
+            <gco:LocalName codeSpace="unknown"/>
+         </gmd:featureTypes>
+         <gmd:featureCatalogueCitation>
+            <gmd:CI_Citation>
+               <gmd:title>
+                  <gco:CharacterString/>
+               </gmd:title>
+               <gmd:date>
+                  <gmd:CI_Date>
+                     <gmd:date>
+                        <gco:Date>2015</gco:Date>
+                     </gmd:date>
+                     <gmd:dateType>
+                        <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                             codeListValue="publication"
+                                             codeSpace="002"/>
+                     </gmd:dateType>
+                  </gmd:CI_Date>
+               </gmd:date>
+               <gmd:citedResponsibleParty xlink:href="https://www.ngdc.noaa.gov/docucomp/1df27e57-4768-42de-909b-52f530601fba"
+                                          xlink:title="U.S Department of Commerce, U.S Census Bureau, Geography Division (distributor)"/>
+               <gmd:otherCitationDetails>
+                  <gco:CharacterString>http://meta.geo.census.gov/data/existing/decennial/GEO/GPMB/TIGERline/TIGER2015/zcta510/2015_zcta510.shp.ea.iso.xml</gco:CharacterString>
+               </gmd:otherCitationDetails>
+            </gmd:CI_Citation>
+         </gmd:featureCatalogueCitation>
+      </gmd:MD_FeatureCatalogueDescription>
+   </gmd:contentInfo>
+   <gmd:distributionInfo>
+      <gmd:MD_Distribution>
+         <gmd:distributionFormat>
+            <gmd:MD_Format>
+               <gmd:name>
+                  <gco:CharacterString>TGRSHP (compressed)</gco:CharacterString>
+               </gmd:name>
+               <gmd:version gco:nilReason="unknown"/>
+               <gmd:fileDecompressionTechnique>
+                  <gco:CharacterString>The TIGER/Line shapefiles contain geographic data only and do not include display mapping software or statistical data.  For information on how to use the TIGER/Line shapefile data with specific software package users shall contact the company that produced the software.</gco:CharacterString>
+               </gmd:fileDecompressionTechnique>
+            </gmd:MD_Format>
+         </gmd:distributionFormat>
+         <gmd:distributionFormat>
+            <gmd:MD_Format>
+               <gmd:name>
+                  <gco:CharacterString>html</gco:CharacterString>
+               </gmd:name>
+               <gmd:version gco:nilReason="unknown"/>
+            </gmd:MD_Format>
+         </gmd:distributionFormat>
+         <gmd:distributor>
+            <gmd:MD_Distributor>
+               <gmd:distributorContact xlink:href="https://www.ngdc.noaa.gov/docucomp/f48e4893-a57f-4f2b-ad5d-0cca1b34ec62"
+                                       xlink:title="U.S Department of Commerce, U.S Census Bureau, Geography Division, Geographic Products Branch (distributor)"/>
+               <gmd:distributionOrderProcess>
+                  <gmd:MD_StandardOrderProcess>
+                     <gmd:fees>
+                        <gco:CharacterString>The online copy of the TIGER/Line Shapefiles may be accessed without charge.</gco:CharacterString>
+                     </gmd:fees>
+                     <gmd:orderingInstructions>
+                        <gco:CharacterString>To obtain more information about ordering TIGER/Line Shapefiles visit http://www.census.gov/geo/www/tiger </gco:CharacterString>
+                     </gmd:orderingInstructions>
+                  </gmd:MD_StandardOrderProcess>
+               </gmd:distributionOrderProcess>
+            </gmd:MD_Distributor>
+         </gmd:distributor>
+         <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+               <gmd:onLine>
+                  <gmd:CI_OnlineResource>
+                     <gmd:linkage>
+                        <gmd:URL>http://www2.census.gov/geo/tiger/TIGER2015/ZCTA510/tl_2015_us_zcta510.zip</gmd:URL>
+                     </gmd:linkage>
+                     <gmd:name>
+                        <gco:CharacterString>Shapefile Zip File</gco:CharacterString>
+                     </gmd:name>
+                  </gmd:CI_OnlineResource>
+               </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+         </gmd:transferOptions>
+         <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+               <gmd:onLine>
+                  <gmd:CI_OnlineResource>
+                     <gmd:linkage>
+                        <gmd:URL>http://www.census.gov/geo/maps-data/data/tiger-line.html</gmd:URL>
+                     </gmd:linkage>
+                     <gmd:name>
+                        <gco:CharacterString>TIGER/Line® Shapefiles</gco:CharacterString>
+                     </gmd:name>
+                     <gmd:description>
+                        <gco:CharacterString>Should be used for most mapping projects--this is our most comprehensive dataset. Designed for use with GIS (geographic information systems).</gco:CharacterString>
+                     </gmd:description>
+                  </gmd:CI_OnlineResource>
+               </gmd:onLine>
+            </gmd:MD_DigitalTransferOptions>
+         </gmd:transferOptions>
+      </gmd:MD_Distribution>
+   </gmd:distributionInfo>
+   <gmd:dataQualityInfo>
+      <gmd:DQ_DataQuality>
+         <gmd:scope>
+            <gmd:DQ_Scope>
+               <gmd:level>
+                  <gmd:MD_ScopeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ScopeCode"
+                                    codeListValue="dataset"
+                                    codeSpace="005"> dataset </gmd:MD_ScopeCode>
+               </gmd:level>
+            </gmd:DQ_Scope>
+         </gmd:scope>
+         <gmd:report>
+            <gmd:DQ_CompletenessCommission>
+               <gmd:result gco:nilReason="unknown"/>
+            </gmd:DQ_CompletenessCommission>
+         </gmd:report>
+         <gmd:report>
+            <gmd:DQ_CompletenessOmission>
+               <gmd:evaluationMethodDescription>
+                  <gco:CharacterString>Data completeness of the TIGER/Line Shapefiles reflects the contents of the Census MAF/TIGER database at the time the TIGER/Line Shapefiles were created.</gco:CharacterString>
+               </gmd:evaluationMethodDescription>
+               <gmd:result gco:nilReason="unknown"/>
+            </gmd:DQ_CompletenessOmission>
+         </gmd:report>
+         <gmd:report>
+            <gmd:DQ_ConceptualConsistency>
+               <gmd:measureDescription>
+                  <gco:CharacterString>The Census Bureau performed automated tests to ensure logical consistency and limits of shapefiles.  Segments making up the outer and inner boundaries of a polygon tie end-to-end to completely enclose the area.  All polygons are tested for closure.
+The Census Bureau uses its internally developed geographic update system to enhance and modify spatial and attribute data in the Census MAF/TIGER database.  Standard geographic codes, such as FIPS codes for states, counties, municipalities, county subdivisions, places, American Indian/Alaska Native/Native Hawaiian areas, and congressional districts are used when encoding spatial entities.  The Census Bureau performed spatial data tests for logical consistency of the codes during the compilation of the original Census MAF/TIGER database files.  Most of the codes for geographic entities except states, counties, urban areas, Core Based Statistical Areas (CBSAs), American Indian Areas (AIAs), and congressional districts were provided to the Census Bureau by the USGS, the agency responsible for maintaining the Geographic Names Information System (GNIS).  Feature attribute information has been examined but has not been fully tested for consistency.
+For the TIGER/Line Shapefiles, the Point and Vector Object Count for the G-polygon SDTS Point and Vector Object Type reflects the number of records in the shapefile attribute table.  For multi-polygon features, only one attribute record exists for each multi-polygon rather than one attribute record per individual G-polygon component of the multi-polygon feature.  TIGER/Line Shapefile multi-polygons are an exception to the G-polygon object type classification.  Therefore, when multi-polygons exist in a shapefile, the object count will be less than the actual number of G-polygons.</gco:CharacterString>
+               </gmd:measureDescription>
+               <gmd:result gco:nilReason="unknown"/>
+            </gmd:DQ_ConceptualConsistency>
+         </gmd:report>
+         <gmd:lineage>
+            <gmd:LI_Lineage>
+               <gmd:processStep>
+                  <gmd:LI_ProcessStep>
+                     <gmd:description>
+                        <gco:CharacterString>TIGER/Line Shapefiles are extracted from the Census MAF/TIGER database by nation, state, county, and entity.  Census MAF/TIGER data for all of the aforementioned geographic entities are then distributed among the shapefiles each containing attributes for line, polygon, or landmark geographic data. </gco:CharacterString>
+                     </gmd:description>
+                     <gmd:dateTime>
+                        <gco:DateTime>2015-01-01T00:00:00</gco:DateTime>
+                     </gmd:dateTime>
+                     <gmd:source>
+                        <gmd:LI_Source>
+                           <gmd:description>
+                              <gco:CharacterString>online</gco:CharacterString>
+                           </gmd:description>
+                           <gmd:sourceCitation>
+                              <gmd:CI_Citation>
+                                 <gmd:title>
+                                    <gco:CharacterString>Census MAF/TIGER database</gco:CharacterString>
+                                 </gmd:title>
+                                 <gmd:alternateTitle>
+                                    <gco:CharacterString>MAF/TIGER</gco:CharacterString>
+                                 </gmd:alternateTitle>
+                                 <gmd:date>
+                                    <gmd:CI_Date>
+                                       <gmd:date>
+                                          <gco:Date>201505</gco:Date>
+                                       </gmd:date>
+                                       <gmd:dateType>
+                                          <gmd:CI_DateTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode"
+                                                               codeListValue="Publication Date"
+                                                               codeSpace="003">Publication Date</gmd:CI_DateTypeCode>
+                                       </gmd:dateType>
+                                    </gmd:CI_Date>
+                                 </gmd:date>
+                                 <gmd:citedResponsibleParty>
+                                    <gmd:CI_ResponsibleParty>
+                                       <gmd:organisationName>
+                                          <gco:CharacterString>U.S. Department of Commerce, U.S. Census Bureau, Geography Division</gco:CharacterString>
+                                       </gmd:organisationName>
+                                       <gmd:role>
+                                          <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_RoleCode"
+                                                           codeListValue="originator">originator
+                                             </gmd:CI_RoleCode>
+                                       </gmd:role>
+                                    </gmd:CI_ResponsibleParty>
+                                 </gmd:citedResponsibleParty>
+                                 <gmd:otherCitationDetails>
+                                    <gco:CharacterString> Source Contribution: All line segments</gco:CharacterString>
+                                 </gmd:otherCitationDetails>
+                              </gmd:CI_Citation>
+                           </gmd:sourceCitation>
+                        </gmd:LI_Source>
+                     </gmd:source>
+                  </gmd:LI_ProcessStep>
+               </gmd:processStep>
+            </gmd:LI_Lineage>
+         </gmd:lineage>
+      </gmd:DQ_DataQuality>
+   </gmd:dataQualityInfo>
+   <gmd:metadataMaintenance>
+      <gmd:MD_MaintenanceInformation>
+         <gmd:maintenanceAndUpdateFrequency>
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_MaintenanceFrequencyCode"
+                                             codeListValue="notPlanned"
+                                             codeSpace="011">
+                         notPlanned
+                </gmd:MD_MaintenanceFrequencyCode>
+         </gmd:maintenanceAndUpdateFrequency>
+         <gmd:maintenanceNote>
+            <gco:CharacterString>This was transformed from the Census Metadata Import Format</gco:CharacterString>
+         </gmd:maintenanceNote>
+         <gmd:contact xlink:href="https://www.ngdc.noaa.gov/docucomp/B04DFA5D-40CD-B677-E040-0AC8C5BB4473"
+                      xlink:title=" U.S. Department of Commerce, U.S. Census Bureau, Geography Division, Geographic Products Branch (custodian)"/>
+      </gmd:MD_MaintenanceInformation>
+   </gmd:metadataMaintenance>
+</gmi:MI_Metadata>

--- a/unzip.js
+++ b/unzip.js
@@ -8,3 +8,4 @@ require('setimmediate');
 exports.Parse = require('./lib/parse');
 exports.ParseOne = require('./lib/parseOne');
 exports.Extract = require('./lib/extract');
+exports.Open = require('./lib/Open');


### PR DESCRIPTION
Previous methods rely on the entire zipfile being received through a pipe.  The Open methods load take a different approach: load the central directory first (at the end of the zipfile) and provide the ability to pick and choose which zipfiles to extract, even extracting them in parallel.   The open methods return a promise on the contents of the directory, with individual `files` listed in an array.   Each file element has the following methods:
* `stream()` - returns a stream of the unzipped content which can be piped to any destination
* `buffer` - returns a promise on the buffered content of the file)