### PR TITLE
Fixing uncaught stream event error in case of multiples piped stream

### DIFF
--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -63,7 +63,7 @@ PullStream.prototype.stream = function(eof,includeEof) {
     if (!done) {
       if (self.finished && !this.__ended) {
         self.removeListener('chunk',pull);
-        p.emit('error','FILE_ENDED');
+        self.emit('error','FILE_ENDED');
         this.__ended = true;
         return;
       }


### PR DESCRIPTION
When using a stream chain like

var a = createStream();
a.pipe(b).pipe(c);

this specific error is not caught and cause the whole app to crash.