### PR TITLE
Hotfix: callback when eof is buffer

### DIFF
--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -56,7 +56,7 @@ PullStream.prototype.stream = function(eof,includeEof) {
         }
       }
       p.write(packet,function() {
-        if (!self.buffer.length) self.cb();
+        if (self.buffer.length === (eof.length || 0)) self.cb();
       });
     }
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [


### PR DESCRIPTION
Callback should be called when buffer is zero length OR has the length of the eof (if buffer)