### PR TITLE
Fix parseOne: pass `error` from `entry` to `out`

### DIFF
--- a/lib/parseOne.js
+++ b/lib/parseOne.js
@@ -19,6 +19,10 @@ function parseOne(match,opts) {
       return cb();
     } else {
       found = true;
+      outStream.emit('entry',entry);
+      entry.on('error',function(e) {
+        outStream.emit('error',e);
+      });
       entry.pipe(outStream)
         .on('error',function(err) {
           cb(err);
@@ -30,6 +34,9 @@ function parseOne(match,opts) {
   };
 
   inStream.pipe(Parse(opts))
+    .on('error',function(err) {
+      outStream.emit('error',err);
+    })
     .pipe(transform)
     .on('finish',function() {
       if (!found)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [

--- a/test/parseOneEntry.js
+++ b/test/parseOneEntry.js
@@ -3,7 +3,6 @@
 var test = require('tap').test;
 var fs = require('fs');
 var path = require('path');
-var temp = require('temp');
 var streamBuffers = require("stream-buffers");
 var unzip = require('../');
 var Stream = require('stream');
@@ -35,4 +34,13 @@ test('errors if file is not found', function (t) {
       t.equal(e.message,'PATTERN_NOT_FOUND');
       t.end();
     });
+});
+
+test('error in zip file', function(t) {
+  unzip.ParseOne()
+    .on('error',function(e) {
+      t.equal(e.message.indexOf('invalid signature'),0);
+      t.end();
+    })
+    .end('this is not a zip file');
 });


### PR DESCRIPTION
The following now works:
```js
test('error in zip file', function(t) {
  unzip.ParseOne()
    .on('error',function(e) {
      t.equal(e.message.indexOf('invalid signature'),0);
      t.end();
    })
    .end('this is not a zip file');
});
```