### PR TITLE
Move emit entry until all vars have been fetched

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -106,12 +106,7 @@ Parse.prototype._readFile = function () {
           }
         }
       }
-
-      self.emit('entry', entry);
-
-      if (self._readableState.pipesCount)
-        self.push(entry);
-        
+       
       self.pull(vars.extraFieldLength).then(function(extraField) {
         var extra = binary.parse(extraField)
           .word16lu('signature')
@@ -127,6 +122,14 @@ Parse.prototype._readFile = function () {
         
         if (vars.uncompressedSize  === 0xffffffff)
           vars.uncompressedSize= extra.uncompressedSize;
+
+        entry.vars = vars;
+        entry.extra = extra;
+
+        self.emit('entry', entry);
+
+        if (self._readableState.pipesCount)
+          self.push(entry);
 
         if (self._opts.verbose)
           console.log({


### PR DESCRIPTION
And includes `.vars` and `.extra` in the entry object

closes https://github.com/ZJONSSON/node-unzipper/issues/36