### PR TITLE
Fix request version (to avoid ES6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "aws-sdk": "^2.77.0",
-    "request": "^2.79.0",
+    "request": "2.79.0",
     "tap": ">= 0.3.0 < 1",
     "temp": ">= 0.4.0 < 1",
     "dirdiff": ">= 0.0.1 < 1",


### PR DESCRIPTION
Stick to the explicit version to avoid ES6 language (which fails the node 0.8 tests).
Request is a devdependency and not used directly in `unzipper`