### PR TITLE
Find the ZIP64 extra field even if there are other extra fields

### DIFF
--- a/lib/Open/unzip.js
+++ b/lib/Open/unzip.js
@@ -32,25 +32,41 @@ module.exports = function unzip(source,offset,_password) {
         .word16lu('fileNameLength')
         .word16lu('extraFieldLength')
         .vars;
-      return file.pull(vars.fileNameLength)    
+      return file.pull(vars.fileNameLength)
         .then(function(fileName) {
           vars.fileName = fileName.toString('utf8');
           return file.pull(vars.extraFieldLength);
         })
         .then(function(extraField) {
-          var extra = binary.parse(extraField)
-            .word16lu('signature')
-            .word16lu('partsize')
-            .word64lu('uncompressedSize')
-            .word64lu('compressedSize')
-            .word64lu('offset')
-            .word64lu('disknum')
-            .vars,
-            checkEncryption;
+          var extra, checkEncryption;
+          // Find the ZIP64 header, if present.
+          while(!extra && extraField && extraField.length) {
+            var candidateExtra = binary.parse(extraField)
+              .word16lu('signature')
+              .word16lu('partsize')
+              .vars;
+
+            if(candidateExtra.signature === 0x0001) {
+              extra = binary.parse(extraField)
+                .word16lu('signature')
+                .word16lu('partsize')
+                .word64lu('uncompressedSize')
+                .word64lu('compressedSize')
+                .word64lu('offset')
+                .word64lu('disknum')
+                .vars;
+            } else {
+              // Advance the buffer to the next part.
+              // The total size of this part is the 4 byte header + partsize.
+              extraField = extraField.slice(candidateExtra.partsize + 4);
+            }
+          }
+
+          extra = extra || {};
 
           if (vars.compressedSize === 0xffffffff)
             vars.compressedSize = extra.compressedSize;
-          
+
           if (vars.uncompressedSize  === 0xffffffff)
             vars.uncompressedSize= extra.uncompressedSize;
 
@@ -124,5 +140,5 @@ module.exports = function unzip(source,offset,_password) {
       entry.emit('error',e);
     });
 
-  return entry;       
+  return entry;
 };


### PR DESCRIPTION
Some zip files have multiple extra fields and so the ZIP64 extra field will not always be the first one. This PR accounts for that, skipping through the extra fields until it finds the ZIP64 header, if present.

Fixes #48 