### PR TITLE
Zip64 parse applied everywhere + test headers

### DIFF
--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -3,6 +3,7 @@ var PullStream = require('../PullStream');
 var unzip = require('./unzip');
 var Promise = require('bluebird');
 var BufferStream = require('../BufferStream');
+var parseExtraField = require('../parseExtraField');
 
 var signature = Buffer(4);
 signature.writeUInt32LE(0x06054b50,0);
@@ -62,6 +63,7 @@ module.exports = function centralDirectory(source) {
           return records.pull(vars.extraFieldLength);
         })
         .then(function(extraField) {
+          vars.extra = parseExtraField(extraField, vars);
           return records.pull(vars.fileCommentLength);
         })
         .then(function(comment) {

--- a/lib/Open/unzip.js
+++ b/lib/Open/unzip.js
@@ -4,6 +4,7 @@ var PullStream = require('../PullStream');
 var Stream = require('stream');
 var binary = require('binary');
 var zlib = require('zlib');
+var parseExtraField = require('../parseExtraField');
 
 // Backwards compatibility for node versions < 8
 if (!Stream.Writable || !Stream.Writable.prototype.destroy)
@@ -40,35 +41,8 @@ module.exports = function unzip(source,offset,_password) {
           return file.pull(vars.extraFieldLength);
         })
         .then(function(extraField) {
-          var extra, checkEncryption;
-          // Find the ZIP64 header, if present.
-          while(!extra && extraField && extraField.length) {
-            var candidateExtra = binary.parse(extraField)
-              .word16lu('signature')
-              .word16lu('partsize')
-              .word64lu('uncompressedSize')
-              .word64lu('compressedSize')
-              .word64lu('offset')
-              .word64lu('disknum')
-              .vars;
-
-            if(candidateExtra.signature === 0x0001) {
-              extra = candidateExtra;
-            } else {
-              // Advance the buffer to the next part.
-              // The total size of this part is the 4 byte header + partsize.
-              extraField = extraField.slice(candidateExtra.partsize + 4);
-            }
-          }
-
-          extra = extra || {};
-
-          if (vars.compressedSize === 0xffffffff)
-            vars.compressedSize = extra.compressedSize;
-
-          if (vars.uncompressedSize  === 0xffffffff)
-            vars.uncompressedSize= extra.uncompressedSize;
-
+          var checkEncryption;
+          vars.extra = parseExtraField(extraField, vars);
           if (vars.flags & 0x01) checkEncryption = file.pull(12)
             .then(function(header) {
               if (!_password)

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -6,6 +6,7 @@ var Promise = require('bluebird');
 var PullStream = require('./PullStream');
 var NoopStream = require('./NoopStream');
 var BufferStream = require('./BufferStream');
+var parseExtraField = require('./parseExtraField');
 
 // Backwards compatibility for node versions < 8
 if (!Stream.Writable || !Stream.Writable.prototype.destroy)
@@ -108,20 +109,7 @@ Parse.prototype._readFile = function () {
       }
        
       self.pull(vars.extraFieldLength).then(function(extraField) {
-        var extra = binary.parse(extraField)
-          .word16lu('signature')
-          .word16lu('partsize')
-          .word64lu('uncompressedSize')
-          .word64lu('compressedSize')
-          .word64lu('offset')
-          .word64lu('disknum')
-          .vars;
-       
-        if (vars.compressedSize === 0xffffffff)
-          vars.compressedSize = extra.compressedSize;
-        
-        if (vars.uncompressedSize  === 0xffffffff)
-          vars.uncompressedSize= extra.uncompressedSize;
+        var extra = parseExtraField(extraField, vars);
 
         entry.vars = vars;
         entry.extra = extra;

--- a/lib/parseExtraField.js
+++ b/lib/parseExtraField.js
@@ -1,0 +1,34 @@
+var binary = require('binary');
+
+module.exports = function(extraField, vars) {
+  var extra;
+  // Find the ZIP64 header, if present.
+  while(!extra && extraField && extraField.length) {
+    var candidateExtra = binary.parse(extraField)
+      .word16lu('signature')
+      .word16lu('partsize')
+      .word64lu('uncompressedSize')
+      .word64lu('compressedSize')
+      .word64lu('offset')
+      .word64lu('disknum')
+      .vars;
+
+    if(candidateExtra.signature === 0x0001) {
+      extra = candidateExtra;
+    } else {
+      // Advance the buffer to the next part.
+      // The total size of this part is the 4 byte header + partsize.
+      extraField = extraField.slice(candidateExtra.partsize + 4);
+    }
+  }
+
+  extra = extra || {};
+
+  if (vars.compressedSize === 0xffffffff)
+    vars.compressedSize = extra.compressedSize;
+
+  if (vars.uncompressedSize  === 0xffffffff)
+    vars.uncompressedSize= extra.uncompressedSize;
+
+  return extra;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [

--- a/test/zip64.js
+++ b/test/zip64.js
@@ -1,46 +1,47 @@
 'use strict';
 
-var test = require('tap').test;
+var t = require('tap');
 var path = require('path');
 var unzip = require('../');
+var fs = require('fs');
 var Stream = require('stream');
+
+var UNCOMPRESSED_SIZE = 5368709120;
 
 // Backwards compatibility for node versions < 8
 if (!Stream.Writable || !Stream.Writable.prototype.destroy)
   Stream = require('readable-stream');
 
 
-test("Correct uncompressed size for zip64", function (t) {
+t.test('Correct uncompressed size for zip64', function (t) {
+  var archive = path.join(__dirname, '../testData/big.zip');
 
-  process.on('uncaughtException', function(e) {
-    t.error('Uncaught Exception: '+e.message);
-    t.end();
+  t.test('in unzipper.Open', function(t) {
+    unzip.Open.file(archive)
+    .then(function(d) {
+      var file = d.files[0];
+      t.same(file.uncompressedSize, UNCOMPRESSED_SIZE, 'Open: Directory header');
+      
+      d.files[0].stream()
+        .on('vars', function(vars) {
+          t.same(vars.uncompressedSize, UNCOMPRESSED_SIZE, 'Open: File header');
+          t.end();
+        })
+        .on('error', function(e) {
+          t.same(e.message,'FILE_ENDED');
+          t.end();
+        });
+    });
   });
 
-
-  
-  var countStream = Stream.Transform();
-  countStream._transform = function(d, e, cb) {
-    this.length = (this.length || 0) + d.length;
-    cb();
-  };
-
-  var archive = path.join(__dirname, '../testData/big.zip');
-  return unzip.Open.file(archive)
-  .then(function(d) {
-    var file = d.files[0];
-    file.stream()
-      .on('error', (e) => {
-        t.same(e.message,'FILE_ENDED');
-        t.end();
-      })
-      .pipe(countStream)
-      .on('error', function(e) {
-        return Promise.reject('Error: '+e.message);
-      })
-      .on('finish', function() {
-        t.same(countStream.length,file.uncompressedSize);
+  t.test('in unzipper.parse', function(t) {
+    fs.createReadStream(archive)
+      .pipe(unzip.Parse())
+      .on('entry', function(entry) {
+        t.same(entry.vars.uncompressedSize, UNCOMPRESSED_SIZE, 'Parse: File header');
         t.end();
       });
   });
+
+  t.end();  
 });

--- a/test/zip64.js
+++ b/test/zip64.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var test = require('tap').test;
+var path = require('path');
+var unzip = require('../');
+var Stream = require('stream');
+
+// Backwards compatibility for node versions < 8
+if (!Stream.Writable || !Stream.Writable.prototype.destroy)
+  Stream = require('readable-stream');
+
+
+test("Correct uncompressed size for zip64", function (t) {
+
+  process.on('uncaughtException', function(e) {
+    t.error('Uncaught Exception: '+e.message);
+    t.end();
+  });
+
+
+  
+  var countStream = Stream.Transform();
+  countStream._transform = function(d, e, cb) {
+    this.length = (this.length || 0) + d.length;
+    cb();
+  };
+
+  var archive = path.join(__dirname, '../testData/big.zip');
+  return unzip.Open.file(archive)
+  .then(function(d) {
+    var file = d.files[0];
+    file.stream()
+      .on('error', (e) => {
+        t.same(e.message,'FILE_ENDED');
+        t.end();
+      })
+      .pipe(countStream)
+      .on('error', function(e) {
+        return Promise.reject('Error: '+e.message);
+      })
+      .on('finish', function() {
+        t.same(countStream.length,file.uncompressedSize);
+        t.end();
+      });
+  });
+});


### PR DESCRIPTION
This is a followup to https://github.com/ZJONSSON/node-unzipper/pull/66 where @dimfeld implemented a code to correctly parse `extraField` in `Open/unzip`.   Here I separate that code into `parseExtraField.js` and apply it in all the places we are loading `extraField` (i.e. `Open/directory.js`, `Open/unzip.js` and `parse.js`)

I also added a zip64 test which verifies that the headers in both `Open` and `parse` show the correct `uncompressedSize`.

@dimfeld can you take a look and see if this makes sense?