### PR TITLE
Set inflater to PassThrough instead of Inflate if we are immediately autodraining.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -78,8 +78,10 @@ Parse.prototype._readFile = function () {
     return self.pull(vars.fileNameLength).then(function(fileName) {
       fileName = fileName.toString('utf8');
       var entry = Stream.PassThrough();
+      var __autodraining = false;
       
       entry.autodrain = function() {
+        __autodraining = true;
         return new Promise(function(resolve,reject) {
           entry.pipe(NoopStream());
           entry.on('finish',resolve);
@@ -129,7 +131,8 @@ Parse.prototype._readFile = function () {
         var fileSizeKnown = !(vars.flags & 0x08),
             eof;
 
-        var inflater = vars.compressionMethod ? zlib.createInflateRaw() : Stream.PassThrough();
+        entry.__autodraining = __autodraining;  // expose __autodraining for test purposes
+        var inflater = (vars.compressionMethod && !__autodraining) ? zlib.createInflateRaw() : Stream.PassThrough();
 
         if (fileSizeKnown) {
           entry.size = vars.uncompressedSize;

--- a/test/autodrain-passthrough.js
+++ b/test/autodrain-passthrough.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var test = require('tap').test;
+var fs = require('fs');
+var path = require('path');
+var unzip = require('../');
+
+test("verify that immediate autodrain does not unzip", function (t) {
+  var archive = path.join(__dirname, '../testData/compressed-standard/archive.zip');
+
+  fs.createReadStream(archive)
+    .pipe(unzip.Parse())
+    .on('entry', function(entry) {
+      entry.autodrain();
+      entry.on('finish', function() {
+        t.equal(entry.__autodraining, true);
+      });
+    })
+    .on('finish', function() {
+      t.end();
+    });
+});


### PR DESCRIPTION
This saves us the cpu effort of deflating content we are immediately throwing away.
closes https://github.com/ZJONSSON/node-unzipper/issues/20