### PR TITLE
Provide `extract` in `unzipper.Open`

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,5 +246,16 @@ unzipper.Open.buffer(buffer)
   });
 ```
 
+### Open.[method].extract()
+
+The directory object returned from `Open.[method]` provides an `extract` method which extracts all the files to a specified `path`, with an optional `concurrency` (default: 1).
+
+Example (with concurrency of 5):
+
+```js
+unzip.Open.file('path/to/archive.zip')
+  .then(d => d.extract({path: '/extraction/path', concurrency: 5}));
+```
+
 ## Licenses
 See LICENCE

--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -68,8 +68,9 @@ module.exports = function centralDirectory(source) {
         })
         .then(function(comment) {
           vars.comment = comment;
+          vars.type = (vars.uncompressedSize === 0 && /[\/\\]$/.test(vars.path)) ? 'Directory' : 'File';
           vars.stream = function(_password) {
-            return unzip(source, vars.offsetToLocalFileHeader,_password);
+            return unzip(source, vars.offsetToLocalFileHeader,_password, vars);
           };
           vars.buffer = function(_password) {
             return BufferStream(vars.stream(_password));

--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -4,6 +4,8 @@ var unzip = require('./unzip');
 var Promise = require('bluebird');
 var BufferStream = require('../BufferStream');
 var parseExtraField = require('../parseExtraField');
+var path = require('path');
+var Writer = require('fstream').Writer;
 
 var signature = Buffer(4);
 signature.writeUInt32LE(0x06054b50,0);
@@ -35,6 +37,32 @@ module.exports = function centralDirectory(source) {
         .vars;
 
       source.stream(vars.offsetToStartOfCentralDirectory).pipe(records);
+
+      vars.extract = function(opts) {
+        if (!opts || !opts.path) throw new Error('PATH_MISSING');
+        return vars.files.then(function(files) {
+          return Promise.map(files, function(entry) {
+            if (entry.type == 'Directory') return;
+
+            // to avoid zip slip (writing outside of the destination), we resolve
+            // the target path, and make sure it's nested in the intended
+            // destination, or not extract it otherwise.
+            var extractPath = path.join(opts.path, entry.path);
+            if (extractPath.indexOf(opts.path) != 0) {
+              return;
+            }
+            var writer = opts.getWriter ? opts.getWriter({path: extractPath}) :  Writer({ path: extractPath });
+
+            return new Promise(function(resolve, reject) {
+              entry.stream(opts.password)
+                .on('error',reject)
+                .pipe(writer)
+                .on('close',resolve)
+                .on('error',reject);
+            });
+          },{concurrency: opts.concurrency || 1});
+        });
+      };
 
       vars.files = Promise.mapSeries(Array(vars.numberOfRecords),function() {
         return records.pull(46).then(function(data) {    

--- a/lib/Open/unzip.js
+++ b/lib/Open/unzip.js
@@ -10,7 +10,7 @@ var parseExtraField = require('../parseExtraField');
 if (!Stream.Writable || !Stream.Writable.prototype.destroy)
   Stream = require('readable-stream');
 
-module.exports = function unzip(source,offset,_password) {
+module.exports = function unzip(source,offset,_password, directoryVars) {
   var file = PullStream(),
       entry = Stream.PassThrough(),
       vars;
@@ -43,6 +43,9 @@ module.exports = function unzip(source,offset,_password) {
         .then(function(extraField) {
           var checkEncryption;
           vars.extra = parseExtraField(extraField, vars);
+          // Ignore logal file header vars if the directory vars are available
+          if (directoryVars && directoryVars.compressedSize) vars = directoryVars;
+
           if (vars.flags & 0x01) checkEncryption = file.pull(12)
             .then(function(header) {
               if (!_password)

--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -22,6 +22,14 @@ function PullStream() {
 
 util.inherits(PullStream,Stream.Duplex);
 
+PullStream.prototype._final = function(cb) {
+  if (!this.done) {
+    this.emit('error', new Error('FILE_ENDED'));
+    return;
+  }
+  setImmediate(cb);
+};
+
 PullStream.prototype._write = function(chunk,e,cb) {
   this.buffer = Buffer.concat([this.buffer,chunk]);
   this.cb = cb;
@@ -33,7 +41,7 @@ PullStream.prototype._write = function(chunk,e,cb) {
 // otherwise (i.e. buffer) it is interpreted as a pattern signaling end of stream
 PullStream.prototype.stream = function(eof,includeEof) {
   var p = Stream.PassThrough();
-  var count = 0,done,packet,self= this;
+  var count = 0,packet,self= this;
 
   function pull() {
     if (self.buffer && self.buffer.length) {
@@ -41,14 +49,14 @@ PullStream.prototype.stream = function(eof,includeEof) {
         packet = self.buffer.slice(0,eof);
         self.buffer = self.buffer.slice(eof);
         eof -= packet.length;
-        done = !eof;
+        self.done = !eof;
       } else {
         var match = self.buffer.indexOf(eof);
         if (match !== -1) {
           if (includeEof) match = match + eof.length;
           packet = self.buffer.slice(0,match);
           self.buffer = self.buffer.slice(match);
-          done = true;
+          self.done = true;
         } else {
           var len = self.buffer.length - eof.length;
           packet = self.buffer.slice(0,len);
@@ -60,16 +68,7 @@ PullStream.prototype.stream = function(eof,includeEof) {
       });
     }
     
-    if (!done) {
-      if (self.finished && !self.__ended) {
-        self.cb = null;
-        self.removeListener('chunk',pull);
-        self.emit('error', new Error('FILE_ENDED'));
-        self.__ended = true;
-        return;
-      }
-      
-    } else {
+    if (self.done) {
       self.removeListener('chunk',pull);
       p.end();
     }

--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -56,12 +56,13 @@ PullStream.prototype.stream = function(eof,includeEof) {
         }
       }
       p.write(packet,function() {
-        if (self.buffer.length === (eof.length || 0)) self.cb();
+        if (self.cb && self.buffer.length === (eof.length || 0)) self.cb();
       });
     }
     
     if (!done) {
       if (self.finished && !self.__ended) {
+        self.cb = null;
         self.removeListener('chunk',pull);
         self.emit('error', new Error('FILE_ENDED'));
         self.__ended = true;

--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -61,10 +61,10 @@ PullStream.prototype.stream = function(eof,includeEof) {
     }
     
     if (!done) {
-      if (self.finished && !this.__ended) {
+      if (self.finished && !self.__ended) {
         self.removeListener('chunk',pull);
         self.emit('error', new Error('FILE_ENDED'));
-        this.__ended = true;
+        self.__ended = true;
         return;
       }
       

--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -2,6 +2,10 @@ var Stream = require('stream');
 var Promise = require('bluebird');
 var util = require('util');
 var Buffer = require('buffer').Buffer;
+var bindexOf;
+
+if (!Buffer.prototype.indexOf)
+  bindexOf = require('buffer-indexof');
 
 // Backwards compatibility for node versions < 8
 if (!Stream.Writable || !Stream.Writable.prototype.destroy)
@@ -51,7 +55,7 @@ PullStream.prototype.stream = function(eof,includeEof) {
         eof -= packet.length;
         self.done = !eof;
       } else {
-        var match = self.buffer.indexOf(eof);
+        var match = bindexOf ? bindexOf(self.buffer, eof) : self.buffer.indexOf(eof);
         if (match !== -1) {
           if (includeEof) match = match + eof.length;
           packet = self.buffer.slice(0,match);

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -19,7 +19,7 @@ function Extract (opts) {
 
   function checkFinished() {
     if (pending === 0 && finishCb) {
-      _final ? _final(finishCb) : finishCb();
+      _final ? _final.call(self, finishCb) : finishCb();
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "big-integer": "^1.6.17",
     "binary": "~0.3.0",
     "bluebird": "~3.4.1",
+    "buffer-indexof": "^1.1.1",
     "buffer-indexof-polyfill": "~1.0.0",
     "duplexer2": "~0.1.4",
     "fstream": "~1.0.10",

--- a/test/check-error.js
+++ b/test/check-error.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var test = require('tap').test;
+var fs = require('fs');
+var path = require('path');
+var PullStream = require('../lib/PullStream');
+
+test("Finish not emitted if there is an error", function (t) {
+  var archive = path.join(__dirname, '../testData/compressed-standard/archive.zip');
+
+  var p = PullStream();
+  var finishEmitted = false;
+
+  fs.createReadStream(archive)
+    .pipe(p)
+    .on('error', function(e) {
+      t.same(e.message,'FILE_ENDED');
+      setTimeout(function() {
+        t.same(finishEmitted,false);
+        t.end();
+      },100);
+    })
+    .on('finish', function() {
+      finishEmitted = true;
+    })
+    .on('close', function() {
+      finishEmitted = true;
+    });
+
+  p.stream('something_not_found');
+});

--- a/test/open-extract.js
+++ b/test/open-extract.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var test = require('tap').test;
+var path = require('path');
+var temp = require('temp');
+var dirdiff = require('dirdiff');
+var unzip = require('../');
+
+
+test("extract compressed archive with open.file.extract", function (t) {
+  var archive = path.join(__dirname, '../testData/compressed-standard/archive.zip');
+
+  temp.mkdir('node-unzip-2', function (err, dirPath) {
+    if (err) {
+      throw err;
+    }
+    unzip.Open.file(archive)
+      .then(function(d) {
+        return d.extract({path: dirPath});
+      })
+      .then(function() {
+        dirdiff(path.join(__dirname, '../testData/compressed-standard/inflated'), dirPath, {
+          fileContents: true
+        }, function (err, diffs) {
+          if (err) {
+            throw err;
+          }
+          t.equal(diffs.length, 0, 'extracted directory contents');
+          t.end();
+        });
+      });
+    
+  });
+});


### PR DESCRIPTION
closes https://github.com/ZJONSSON/node-unzipper/issues/57

Use central directory information (if available) instead of local file information.
Provide extract method to the directory returned from `open`
