### PR TITLE
Autodrain should return the `NoopStream` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,18 @@ Extract emits the 'close' event once the zip's contents have been fully extracte
 Process each zip file entry or pipe entries to another stream.
 
 __Important__: If you do not intend to consume an entry stream's raw data, call autodrain() to dispose of the entry's
-contents. Otherwise you the stream will halt.
+contents. Otherwise you the stream will halt.   `.autodrain()` returns an empty stream that provides `error` and `finish` events.
+Additionally you can call `.autodrain().promise()` to get the promisified version of success or failure of the autodrain.
+
+```
+// If you want to handle autodrain errors you can either:
+entry.autodrain().catch(e => handleError);
+// or
+entry.autodrain().on('error' => handleError);
+```
+
+Here is a quick example:
+
 
 ```js
 fs.createReadStream('path/to/archive.zip')

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -82,11 +82,14 @@ Parse.prototype._readFile = function () {
       
       entry.autodrain = function() {
         __autodraining = true;
-        return new Promise(function(resolve,reject) {
-          entry.pipe(NoopStream());
-          entry.on('finish',resolve);
-          entry.on('error',reject);
-        });
+        var draining = entry.pipe(NoopStream());
+        draining.promise = function() {
+          return new Promise(function(resolve, reject) {
+            draining.on('finish',resolve);
+            draining.on('error',reject);
+          });
+        };
+        return draining;
       };
 
       entry.buffer = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [

--- a/test/autodrain-passthrough.js
+++ b/test/autodrain-passthrough.js
@@ -11,10 +11,27 @@ test("verify that immediate autodrain does not unzip", function (t) {
   fs.createReadStream(archive)
     .pipe(unzip.Parse())
     .on('entry', function(entry) {
-      entry.autodrain();
-      entry.on('finish', function() {
-        t.equal(entry.__autodraining, true);
-      });
+      entry.autodrain()
+        .on('finish', function() {
+          t.equal(entry.__autodraining, true);
+        });
+    })
+    .on('finish', function() {
+      t.end();
+    });
+});
+
+test("verify that autodrain promise works", function (t) {
+  var archive = path.join(__dirname, '../testData/compressed-standard/archive.zip');
+
+  fs.createReadStream(archive)
+    .pipe(unzip.Parse())
+    .on('entry', function(entry) {
+      entry.autodrain()
+        .promise()
+        .then(function() {
+          t.equal(entry.__autodraining, true);
+        });
     })
     .on('finish', function() {
       t.end();


### PR DESCRIPTION
but provide access to a generated promise of success through a `.promise()` method.

closes https://github.com/ZJONSSON/node-unzipper/issues/73