### PR TITLE
Upgraded library to make it compatible with latest node versions

### DIFF
--- a/lib/Buffer.js
+++ b/lib/Buffer.js
@@ -1,0 +1,12 @@
+var Buffer = require('buffer').Buffer;
+
+// Backwards compatibility for node versions < 8
+if (Buffer.from === undefined) {
+  Buffer.from = function (a, b, c) {
+    return new Buffer(a, b, c)
+  };
+
+  Buffer.alloc = Buffer.from;
+}
+
+module.exports = Buffer;

--- a/lib/BufferStream.js
+++ b/lib/BufferStream.js
@@ -1,6 +1,6 @@
 var Promise = require('bluebird');
-var Buffer = require('buffer').Buffer;
 var Stream = require('stream');
+var Buffer = require('./Buffer');
 
 // Backwards compatibility for node versions < 8
 if (!Stream.Writable || !Stream.Writable.prototype.destroy)
@@ -8,7 +8,7 @@ if (!Stream.Writable || !Stream.Writable.prototype.destroy)
 
 module.exports = function(entry) {
   return new Promise(function(resolve,reject) {
-    var buffer = new Buffer(''),
+    var buffer = Buffer.from(''),
         bufferStream = Stream.Transform()
           .on('finish',function() {
             resolve(buffer);

--- a/lib/Decrypt.js
+++ b/lib/Decrypt.js
@@ -25,7 +25,7 @@ function crc(ch,crc) {
   if (ch.charCodeAt)
     ch = ch.charCodeAt(0);        
 
-  return (bigInt(crc).shiftRight(8).and(0xffffff)).xor(table[(crc ^ ch) & 0xff]).value;
+  return (bigInt(crc).shiftRight(8).and(0xffffff)).xor(table[bigInt(crc).xor(ch).and(0xff)]).value;
 }
 
 function Decrypt() {
@@ -39,13 +39,14 @@ function Decrypt() {
 
 Decrypt.prototype.update = function(h) {            
   this.key0 = crc(h,this.key0);
-  this.key1 = this.key1 + (this.key0 & 255) & 4294967295;
+  this.key1 = bigInt(this.key0).and(255).and(4294967295).add(this.key1)
   this.key1 = bigInt(this.key1).multiply(134775813).add(1).and(4294967295).value;
-  this.key2 = crc((this.key1 >> 24) & 255,this.key2);
-};
+  this.key2 = crc(bigInt(this.key1).shiftRight(24).and(255), this.key2);
+}
+
 
 Decrypt.prototype.decryptByte = function(c) {
-  var k = this.key2 | 2; 
+  var k = bigInt(this.key2).or(2);
   c = c ^ bigInt(k).multiply(bigInt(k^1)).shiftRight(8).and(255);
   this.update(c);
   return c;

--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -4,8 +4,9 @@ var unzip = require('./unzip');
 var Promise = require('bluebird');
 var BufferStream = require('../BufferStream');
 var parseExtraField = require('../parseExtraField');
+var Buffer = require('../Buffer');
 
-var signature = Buffer(4);
+var signature = Buffer.alloc(4);
 signature.writeUInt32LE(0x06054b50,0);
 
 module.exports = function centralDirectory(source) {

--- a/lib/Open/unzip.js
+++ b/lib/Open/unzip.js
@@ -5,6 +5,7 @@ var Stream = require('stream');
 var binary = require('binary');
 var zlib = require('zlib');
 var parseExtraField = require('../parseExtraField');
+var Buffer = require('../Buffer');
 
 // Backwards compatibility for node versions < 8
 if (!Stream.Writable || !Stream.Writable.prototype.destroy)
@@ -85,7 +86,7 @@ module.exports = function unzip(source,offset,_password) {
         entry.size = vars.uncompressedSize;
         eof = vars.compressedSize;
       } else {
-        eof = new Buffer(4);
+        eof = Buffer.alloc(4);
         eof.writeUInt32LE(0x08074b50, 0);
       }
 

--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -1,7 +1,7 @@
 var Stream = require('stream');
 var Promise = require('bluebird');
 var util = require('util');
-var Buffer = require('buffer').Buffer;
+var Buffer = require('./Buffer');
 var strFunction = 'function';
 
 // Backwards compatibility for node versions < 8
@@ -13,7 +13,7 @@ function PullStream() {
     return new PullStream();
 
   Stream.Duplex.call(this,{decodeStrings:false, objectMode:true});
-  this.buffer = new Buffer(''); 
+  this.buffer = Buffer.from('');
   var self = this;
   self.on('finish',function() {
     self.finished = true;
@@ -92,7 +92,7 @@ PullStream.prototype.pull = function(eof,includeEof) {
   }
 
   // Otherwise we stream until we have it
-  var buffer = new Buffer(''),
+  var buffer = Buffer.from(''),
       self = this;
 
   var concatStream = Stream.Transform();

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -7,12 +7,13 @@ var PullStream = require('./PullStream');
 var NoopStream = require('./NoopStream');
 var BufferStream = require('./BufferStream');
 var parseExtraField = require('./parseExtraField');
+var Buffer = require('./Buffer');
 
 // Backwards compatibility for node versions < 8
 if (!Stream.Writable || !Stream.Writable.prototype.destroy)
   Stream = require('readable-stream');
 
-var endDirectorySignature = new Buffer(4);
+var endDirectorySignature = Buffer.alloc(4);
 endDirectorySignature.writeUInt32LE(0x06054b50, 0);
 
 function Parse(opts) {
@@ -141,7 +142,7 @@ Parse.prototype._readFile = function () {
           entry.size = vars.uncompressedSize;
           eof = vars.compressedSize;
         } else {
-          eof = new Buffer(4);
+          eof = Buffer.alloc(4);
           eof.writeUInt32LE(0x08074b50, 0);
         }
 


### PR DESCRIPTION
For this moment `node-unzipper` lib is not compatible with latest node versions.

Some tests are failing with the error:
```TypeError: Cannot mix BigInt and other types, use explicit conversions```
it's related to https://github.com/tc39/proposal-bigint

Also there are some warning related to `Buffer`:
``` [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.```

In this PR, `Buffer` is wrapped to the helper that allows to be compatible with all node versions. Also all operations with `BigInt` are reduced to one type.

Thanks a lot for maintaining this library! 🤝

