### PR TITLE
Added a fix for edge case when package length is zero

### DIFF
--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -57,7 +57,12 @@ PullStream.prototype.stream = function(eof,includeEof) {
         }
       }
       p.write(packet,function() {
-        if (self.buffer.length === (eof.length || 0) && typeof self.cb === strFunction) self.cb();
+        if (self.buffer.length === (eof.length || 0) &&
+          typeof self.cb === strFunction &&
+          packet.length !== 0
+        ) {
+          self.cb();
+        }
       });
     }
     


### PR DESCRIPTION
We are using `node-unzipper` for unzipping excel files (under the hood excel files are zip files). And sometimes there is a situation when the error is throwing:
```
error:  Uncaught Exception -- Error [ERR_MULTIPLE_CALLBACK]: Callback called multiple times
    at onwrite (_stream_writable.js:451:11)
    at /Users/John/Unzipper/node_modules/unzipper/lib/PullStream.js:63:16
    at afterWrite (_stream_writable.js:480:3)
    at onwrite (_stream_writable.js:471:7)
    at PassThrough.afterTransform (_stream_transform.js:94:3)
    at PassThrough._transform (_stream_passthrough.js:42:3)
    at PassThrough.Transform._read (_stream_transform.js:190:10)
    at PassThrough.Readable.read (_stream_readable.js:452:10)
    at flow (_stream_readable.js:922:34)
    at InflateRaw.pipeOnDrainFunctionResult (_stream_readable.js:734:7)
    at InflateRaw.emit (events.js:182:13)
    at InflateRaw.EventEmitter.emit (domain.js:442:20)
    at onwriteDrain (_stream_writable.js:490:12)
    at afterWrite (_stream_writable.js:478:5)
    at onwrite (_stream_writable.js:471:7)
    at InflateRaw.afterTransform (_stream_transform.js:94:3)
    at Zlib.processCallback (zlib.js:619:8)
```

After some debugging I didn't manage find the root cause of the problem, but I noticed it's happening when the `package` length is 0 on the line number 60 in the `PullStream.js` file. Adding a simple condition for empty `package` resolves the problem.

Also during the experiments I've found that it's possible to simulate the case with empty `package` var when the `highWatermark` of the source stream is low (1-10) and the archive has folders.

This PR is fixing this problem. However I didn't manage to replicate the case by unit testing. Tested on node > 8.

Thanks a lot for the maintaining `node-unzipper` library 🤝!