### PR TITLE
Delete the callback reference before calling callback

### DIFF
--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -65,7 +65,9 @@ PullStream.prototype.stream = function(eof,includeEof) {
           typeof self.cb === strFunction &&
           packet.length !== 0
         ) {
-          self.cb();
+          var cb = self.cb;
+          delete self.cb;
+          cb();
         }
       });
     }

--- a/test/chunkBoundary.js
+++ b/test/chunkBoundary.js
@@ -25,6 +25,7 @@ test("parse an archive that has a file that falls on a chunk boundary", {
     .on('entry', function(entry) {
         return entry.autodrain();
     }).on("finish", function() {
+        t.ok(true,'file complete');
         t.end();
     });
 });


### PR DESCRIPTION
This ensures we don't call the same callback twice.
This bug was uncovered by @vitalyster running the unit tests on windows here https://github.com/ZJONSSON/node-unzipper/pull/96