### PR TITLE
fix bluebird and event emitter warnings

### DIFF
--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -113,14 +113,16 @@ PullStream.prototype.pull = function(eof,includeEof) {
   };
   
   var rejectHandler;
+  var pullStreamRejectHandler;
   return new Promise(function(resolve,reject) {
     rejectHandler = reject;
-    if (self.finished)
-      return reject(new Error('FILE_ENDED'));
-    self.once('error', function(e) {
+    pullStreamRejectHandler = function(e) {
       self.__emittedError = e;
       reject(e);
-    });  // reject any errors from pullstream itself
+    }
+    if (self.finished)
+      return reject(new Error('FILE_ENDED'));
+    self.once('error',pullStreamRejectHandler);  // reject any errors from pullstream itself
     self.stream(eof,includeEof)
       .on('error',reject)
       .pipe(concatStream)
@@ -129,6 +131,7 @@ PullStream.prototype.pull = function(eof,includeEof) {
   })
   .finally(function() {
     self.removeListener('error',rejectHandler);
+    self.removeListener('error',pullStreamRejectHandler);
   });
 };
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -65,7 +65,7 @@ Parse.prototype._readRecord = function () {
 
 Parse.prototype._readFile = function () {
   var self = this;
-  self.pull(26).then(function(data) {
+  return self.pull(26).then(function(data) {
     var vars = binary.parse(data)
       .word16lu('versionsNeededToExtract')
       .word16lu('flags')
@@ -121,7 +121,7 @@ Parse.prototype._readFile = function () {
         }
       }
        
-      self.pull(vars.extraFieldLength).then(function(extraField) {
+      return self.pull(vars.extraFieldLength).then(function(extraField) {
         var extra = parseExtraField(extraField, vars);
 
         entry.vars = vars;
@@ -160,6 +160,7 @@ Parse.prototype._readFile = function () {
           .on('finish', function() {
             return fileSizeKnown ? self._readRecord() : self._processDataDescriptor(entry);
           });
+        return null; // This prevents bluebird from throwing "promise created but not returned" warnings
       });
     });
   });


### PR DESCRIPTION
This PR fixes two issues.
1. A recent bug fix change caused us to create a new listener for error events, but we never ended up cleaning up that listener. Node was then throwing warnings about too many event emitters. This adds code to remove that event listener.
2. If a promise is created an a function, but not returned from that function bluebird throws warnings. This PR makes bluebird happy.