### PR TITLE
Better fix for boundary

### DIFF
--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -34,7 +34,15 @@ PullStream.prototype._write = function(chunk,e,cb) {
 // otherwise (i.e. buffer) it is interpreted as a pattern signaling end of stream
 PullStream.prototype.stream = function(eof,includeEof) {
   var p = Stream.PassThrough();
-  var count = 0,done,needmore,packet,self= this;
+  var done,packet,self= this;
+
+  function cb() {
+    if (typeof self.cb === strFunction) {
+      var callback = self.cb;
+      self.cb = undefined;
+      return callback();
+    }
+  }
 
   function pull() {
     if (self.buffer && self.buffer.length) {
@@ -52,23 +60,16 @@ PullStream.prototype.stream = function(eof,includeEof) {
           done = true;
         } else {
           var len = self.buffer.length - eof.length;
-          if (len < 0) {
-            len = self.buffer.length;
-            needmore = true;
+          if (len <= 0) {
+            cb();
+          } else {
+            packet = self.buffer.slice(0,len);
+            self.buffer = self.buffer.slice(len);
           }
-          packet = self.buffer.slice(0,len);
-          self.buffer = self.buffer.slice(len);
         }
       }
-      p.write(packet,function() {
-        if ((self.buffer.length === (eof.length || 0) || needmore) &&
-          typeof self.cb === strFunction &&
-          packet.length !== 0
-        ) {
-          var cb = self.cb;
-          delete self.cb;
-          cb();
-        }
+      if (packet) p.write(packet,function() {
+        if (self.buffer.length === 0 || (eof.length && self.buffer.length <= eof.length)) cb();
       });
     }
     

--- a/test/chunkBoundary.js
+++ b/test/chunkBoundary.js
@@ -20,7 +20,7 @@ test("parse an archive that has a file that falls on a chunk boundary", {
   var archive = path.join(__dirname, '../testData/chunk-boundary/chunk-boundary-archive.zip');
 
   // Use an artificially low highWaterMark to make the edge case more likely to happen.
-  fs.createReadStream(archive,{ highWaterMark: 256 })
+  fs.createReadStream(archive,{ highWaterMark: 3 })
     .pipe(unzip.Parse())
     .on('entry', function(entry) {
         return entry.autodrain();


### PR DESCRIPTION
closes https://github.com/ZJONSSON/node-unzipper/issues/122
An elusive bug as it doesn't pop up that often.  But in some cases (where eof is a symbol) we end up with buffer exactly the same length as the symbol (that is not the symbol we are looking for) we would silently fail.

The most important fix here is checking if `self.buffer.length - eof.length <= 0` not just `< 0`

Also simplified and rearranged the callback structure