### PR TITLE
Move variable definition of packet into  `pull()`

### DIFF
--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -34,7 +34,7 @@ PullStream.prototype._write = function(chunk,e,cb) {
 // otherwise (i.e. buffer) it is interpreted as a pattern signaling end of stream
 PullStream.prototype.stream = function(eof,includeEof) {
   var p = Stream.PassThrough();
-  var done,packet,self= this;
+  var done,self= this;
 
   function cb() {
     if (typeof self.cb === strFunction) {
@@ -45,6 +45,7 @@ PullStream.prototype.stream = function(eof,includeEof) {
   }
 
   function pull() {
+    var packet;
     if (self.buffer && self.buffer.length) {
       if (typeof eof === 'number') {
         packet = self.buffer.slice(0,eof);


### PR DESCRIPTION
Otherwise we'll have non-empty packets moving to next pull