### PR TITLE
Bring back chunked-boundary test for node 0.10

### DIFF
--- a/test/chunkBoundary.js
+++ b/test/chunkBoundary.js
@@ -9,14 +9,7 @@ test("parse an archive that has a file that falls on a chunk boundary", {
     timeout: 2000,
 }, function (t) {
 
-  // We ignore this test for node v.10
-  // see: https://github.com/ZJONSSON/node-unzipper/pull/82
-  if (/^v0.10/.test(process.version)) {
-    t.comment('Ignore chunkBoundary test for v0.10');
-    t.end();
-    return;
-  }
-
+  
   var archive = path.join(__dirname, '../testData/chunk-boundary/chunk-boundary-archive.zip');
 
   // Use an artificially low highWaterMark to make the edge case more likely to happen.


### PR DESCRIPTION
With the improved fix for boundary https://github.com/ZJONSSON/node-unzipper/pull/123 the node 0.10 is working again