### PR TITLE
Use endOfDirectory file header instead of local header

### DIFF
--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -71,8 +71,9 @@ module.exports = function centralDirectory(source, options) {
         })
         .then(function(comment) {
           vars.comment = comment;
+          vars.type = (vars.uncompressedSize === 0 && /[\/\\]$/.test(vars.path)) ? 'Directory' : 'File';
           vars.stream = function(_password) {
-            return unzip(source, vars.offsetToLocalFileHeader,_password);
+            return unzip(source, vars.offsetToLocalFileHeader,_password, vars);
           };
           vars.buffer = function(_password) {
             return BufferStream(vars.stream(_password));

--- a/lib/Open/unzip.js
+++ b/lib/Open/unzip.js
@@ -11,7 +11,7 @@ var Buffer = require('../Buffer');
 if (!Stream.Writable || !Stream.Writable.prototype.destroy)
   Stream = require('readable-stream');
 
-module.exports = function unzip(source,offset,_password) {
+module.exports = function unzip(source,offset,_password, directoryVars) {
   var file = PullStream(),
       entry = Stream.PassThrough(),
       vars;
@@ -44,6 +44,9 @@ module.exports = function unzip(source,offset,_password) {
         .then(function(extraField) {
           var checkEncryption;
           vars.extra = parseExtraField(extraField, vars);
+          // Ignore logal file header vars if the directory vars are available
+          if (directoryVars && directoryVars.compressedSize) vars = directoryVars;
+
           if (vars.flags & 0x01) checkEncryption = file.pull(12)
             .then(function(header) {
               if (!_password)


### PR DESCRIPTION
The endOfFile directory contains more reliable information than the local file headers, most importantly accurate information about the compressedSize of each file.