### PR TITLE
Resolve promise on close event

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -46,7 +46,7 @@ function Extract (opts) {
   
   extract.promise = function() {
     return new Promise(function(resolve, reject) {
-      extract.on('finish', resolve);
+      extract.on('close', resolve);
       extract.on('error',reject);
     });
   };

--- a/test/extract-finish.js
+++ b/test/extract-finish.js
@@ -28,7 +28,7 @@ test("Only emit finish/close when extraction has completed", function (t) {
 
       delayStream._flush = function(cb) {
         filesDone += 1;
-        cb();
+        setTimeout(cb, 100);
         delayStream.emit('close');
       };
 
@@ -40,7 +40,7 @@ test("Only emit finish/close when extraction has completed", function (t) {
     unzipExtractor.on('error', function(err) {
       throw err;
     });
-    unzipExtractor.on('close', function() {
+    unzipExtractor.promise().then(function() {
       t.same(filesDone,2);
       t.end();
     });


### PR DESCRIPTION
closes https://github.com/ZJONSSON/node-unzipper/issues/136

The finish event of the duplex stream can fire before the writers are done.  The close event is only fired when we are done writing

* Resolve promise on close event
* Amend test to use promise (would fail without the fix)