### PR TITLE
Filesizeknown

### DIFF
--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -162,7 +162,7 @@ module.exports = function centralDirectory(source, options) {
                 .on('close',resolve)
                 .on('error',reject);
             });
-          },{concurrency: opts.concurrency || 1});
+          }, opts.concurrency > 1 ? {concurrency: opts.concurrency || undefined} : undefined);
         });
       };
 

--- a/lib/Open/unzip.js
+++ b/lib/Open/unzip.js
@@ -83,7 +83,7 @@ module.exports = function unzip(source,offset,_password, directoryVars) {
     });
 
     entry.vars.then(function(vars) {
-      var fileSizeKnown = !(vars.flags & 0x08),
+      var fileSizeKnown = !(vars.flags & 0x08) || vars.compressedSize > 0,
           eof;
 
       var inflater = vars.compressionMethod ? zlib.createInflateRaw() : Stream.PassThrough();

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -164,7 +164,7 @@ Parse.prototype._readFile = function () {
             extra: extra
           });
 
-        var fileSizeKnown = !(vars.flags & 0x08),
+        var fileSizeKnown = !(vars.flags & 0x08) || vars.compressedSize > 0,
             eof;
 
         entry.__autodraining = __autodraining;  // expose __autodraining for test purposes


### PR DESCRIPTION
closes https://github.com/ZJONSSON/node-unzipper/issues/149

Based on further analysis of https://github.com/ZJONSSON/node-unzipper/issues/149 it seems like we can have zipfiles with a positive `compressedSize` that still show up with `fileSizeKnown` flag as false.

Here we assume that a positive compressedSize means we know the size of the compressed gzip stream.