### PR TITLE
Pass error to piped stream in centralDirectory

### DIFF
--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -93,7 +93,11 @@ module.exports = function centralDirectory(source, options) {
   return source.size()
     .then(function(size) {
       sourceSize = size;
-      source.stream(Math.max(0,size-tailSize)).pipe(endDir);
+
+      source.stream(Math.max(0,size-tailSize))
+        .on('error', function (error) { endDir.emit('error', error) })
+        .pipe(endDir);
+
       return endDir.pull(signature);
     })
     .then(function() {


### PR DESCRIPTION
It fixes the process crash when the stream emitting an error event.