### PR TITLE
Fixed extract when opts.path is '.' (dot)

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -9,7 +9,7 @@ var Promise = require('bluebird');
 
 function Extract (opts) {
   // make sure path is normalized before using it
-  opts.path = path.normalize(opts.path);
+  opts.path = path.resolve(path.normalize(opts.path));
 
   var parser = new Parse(opts);
 

--- a/test/extractNormalize.js
+++ b/test/extractNormalize.js
@@ -51,3 +51,42 @@ test("Extract should normalize the path option", function (t) {
     fs.createReadStream(archive).pipe(unzipExtractor);
   });
 });
+
+test("Extract should resolve after normalize the path option", function (t) {
+  var archive = path.join(__dirname, '../testData/compressed-standard/archive.zip');
+
+  temp.mkdir('node-unzip-normalize-2-', function (err, dirPath) {
+    if (err) {
+      throw err;
+    }
+
+    var filesDone = 0;
+
+    function getWriter() {
+      var delayStream = new Stream.Transform();
+
+      delayStream._transform = function(d, e, cb) {
+        setTimeout(cb, 500);
+      };
+
+      delayStream._flush = function(cb) {
+        filesDone += 1;
+        cb();
+        delayStream.emit('close');
+      };
+
+      return delayStream;
+    }
+
+    var unzipExtractor = unzip.Extract({ getWriter: getWriter, path: '.' });
+    unzipExtractor.on('error', function(err) {
+      throw err;
+    });
+    unzipExtractor.on('close', function() {
+      t.same(filesDone,2);
+      t.end();
+    });
+
+    fs.createReadStream(archive).pipe(unzipExtractor);
+  });
+});


### PR DESCRIPTION
Fixed when opts.path is '.' (dot), zip slip checking will be always failed when extracting zip file