### PR TITLE
HOTFIX: Fix pipecount

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+ - "13"
+ - "12"
  - "10"
  - "8"
  - "7"

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -154,7 +154,7 @@ Parse.prototype._readFile = function () {
 
         self.emit('entry', entry);
 
-        if (self._readableState.pipesCount)
+        if (self._readableState.pipesCount || (self._readableState.pipes && self._readableState.pipes.length))
           self.push(entry);
 
         if (self._opts.verbose)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [


### PR DESCRIPTION
closes https://github.com/ZJONSSON/node-unzipper/issues/168

We use undocumented internals to see if we have a `pipeCount` to determine whether we should `push` the current `entry` or not.   For example, if a user is not piping from the stream but using `.on('entry` we don't want the stream to block on the push.  