### PR TITLE
Ensure promises created in Parse are handled

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -178,14 +178,17 @@ Parse.prototype._readFile = function () {
           eof.writeUInt32LE(0x08074b50, 0);
         }
 
-        self.stream(eof)
-          .pipe(inflater)
-          .on('error',function(err) { self.emit('error',err);})
-          .pipe(entry)
-          .on('finish', function() {
-            return fileSizeKnown ? self._readRecord() : self._processDataDescriptor(entry);
-          });
-        return null; // This prevents bluebird from throwing "promise created but not returned" warnings
+        return new Promise(function(resolve, reject) {
+          self.stream(eof)
+            .pipe(inflater)
+            .on('error',function(err) { self.emit('error',err);})
+            .pipe(entry)
+            .on('finish', function() {
+              return fileSizeKnown ?
+                self._readRecord().then(resolve).catch(reject) :
+                self._processDataDescriptor(entry).then(resolve).catch(reject);
+            });
+        });
       });
     });
   });
@@ -193,7 +196,7 @@ Parse.prototype._readFile = function () {
 
 Parse.prototype._processDataDescriptor = function (entry) {
   var self = this;
-  self.pull(16).then(function(data) {
+  return self.pull(16).then(function(data) {
     var vars = binary.parse(data)
       .word32lu('dataDescriptorSignature')
       .word32lu('crc32')
@@ -202,13 +205,13 @@ Parse.prototype._processDataDescriptor = function (entry) {
       .vars;
 
     entry.size = vars.uncompressedSize;
-    self._readRecord();
+    return self._readRecord();
   });
 };
 
 Parse.prototype._readCentralDirectoryFileHeader = function () {
   var self = this;
-  self.pull(42).then(function(data) {
+  return self.pull(42).then(function(data) {
     
     var vars = binary.parse(data)
       .word16lu('versionMadeBy')
@@ -244,7 +247,7 @@ Parse.prototype._readCentralDirectoryFileHeader = function () {
 
 Parse.prototype._readEndOfCentralDirectoryRecord = function() {
   var self = this;
-  self.pull(18).then(function(data) {
+  return self.pull(18).then(function(data) {
     
     var vars = binary.parse(data)
       .word16lu('diskNumber')
@@ -256,7 +259,7 @@ Parse.prototype._readEndOfCentralDirectoryRecord = function() {
       .word16lu('commentLength')
       .vars;
 
-    self.pull(vars.commentLength).then(function(comment) {
+    return self.pull(vars.commentLength).then(function(comment) {
       comment = comment.toString('utf8');
       self.end();
       self.push(null);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [


### PR DESCRIPTION
There are several places in [lib/parse.js](https://github.com/ZJONSSON/node-unzipper/blob/e91734def0a19587b3be9e17567b254f009545df/lib/parse.js) where a promise is created via [PullStream.prototype.pull](https://github.com/ZJONSSON/node-unzipper/blob/e91734def0a19587b3be9e17567b254f009545df/lib/PullStream.js#L99), but not handled (via a `.catch()` that doesn't `throw` or return another rejected promise).

Fixes #171 