### PR TITLE
BufferStream: improve performance by running concat only once at the end

### DIFF
--- a/lib/BufferStream.js
+++ b/lib/BufferStream.js
@@ -8,15 +8,15 @@ if (!Stream.Writable || !Stream.Writable.prototype.destroy)
 
 module.exports = function(entry) {
   return new Promise(function(resolve,reject) {
-    var buffer = Buffer.from(''),
-        bufferStream = Stream.Transform()
-          .on('finish',function() {
-            resolve(buffer);
-          })
-          .on('error',reject);
+    var chunks = [];
+    var bufferStream = Stream.Transform()
+      .on('finish',function() {
+        resolve(Buffer.concat(chunks));
+      })
+      .on('error',reject);
         
     bufferStream._transform = function(d,e,cb) {
-      buffer = Buffer.concat([buffer,d]);
+      chunks.push(d);
       cb();
     };
     entry.on('error',reject)


### PR DESCRIPTION
When trying to unzip 170MB file into a buffer with `entry.buffer()`, my `BufferStream` got to process 10k+ chunks (16kB each) and allocate and copy a new `Buffer` on each chunk. That's very slow and my script didn't finish before I gave up after ~5 minutes.

This patch pushes all the received chunks into an array and concats them all only once after the extraction is finished. With this approach, my program finished within seconds.