### PR TITLE
Place cb behind setImmediate

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -14,7 +14,13 @@ function Extract (opts) {
   var parser = new Parse(opts);
 
   var outStream = new stream.Writable({objectMode: true});
-  outStream._write = function(entry, encoding, cb) {
+  outStream._write = function(entry, encoding, _cb) {
+
+    function cb(err,d) {
+      setImmediate(function() {
+        _cb(err,d);
+      });
+    }
 
     if (entry.type == 'Directory') return cb();
 


### PR DESCRIPTION
closes https://github.com/ZJONSSON/node-unzipper/issues/165

It is possible that the extract callbacks are called before writers have flushed to disk (see referenced issue).  Proposed solution is to place callbacks inside [setImmediate](https://nodejs.org/api/timers.html#timers_setimmediate_callback_args)