### PR TITLE
fix: extract from url not working

### DIFF
--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -146,6 +146,8 @@ module.exports = function centralDirectory(source, options) {
 
       vars.extract = function(opts) {
         if (!opts || !opts.path) throw new Error('PATH_MISSING');
+        // make sure path is normalized before using it
+        opts.path = path.resolve(path.normalize(opts.path));
         return vars.files.then(function(files) {
           return Promise.map(files, function(entry) {
             if (entry.type == 'Directory') return;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "aws-sdk": "^2.77.0",
     "dirdiff": ">= 0.0.1 < 1",
+    "fs-extra": "^9.0.0",
     "iconv-lite": "^0.4.24",
     "request": "^2.88.0",
     "stream-buffers": ">= 0.2.5 < 1",

--- a/test/extractFromUrl.js
+++ b/test/extractFromUrl.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const test = require("tap").test;
+const fs = require("fs-extra");
+const unzip = require("../");
+const os = require("os");
+const request = require("request");
+
+test("extract zip from url", function (t) {
+  const extractPath = os.tmpdir() + "/node-unzip-extract-fromURL"; // Not using path resolve, cause it should be resolved in extract() function
+  unzip.Open.url(
+    request,
+    "https://github.com/h5bp/html5-boilerplate/releases/download/v7.3.0/html5-boilerplate_v7.3.0.zip"
+  )
+    .then((d) => d.extract({ path: extractPath }))
+    .then((d) => {
+      const dirFiles = fs.readdirSync(extractPath);
+      const isPassing =
+        dirFiles.length > 10 &&
+        dirFiles.indexOf("css") > -1 &&
+        dirFiles.indexOf("index.html") > -1 &&
+        dirFiles.indexOf("favicon.ico") > -1;
+
+      t.equal(isPassing, true);
+      fs.remove(extractPath);
+      t.end();
+    });
+});


### PR DESCRIPTION
```js
opts.path = path.resolve(path.normalize(opts.path));
```
was missing in `lib/Open/directory.js` as a result extract didn't working.
I added `fs-extra` in order to remove the temp folder after test finished.