### PR TITLE
docs(parseOne): last pipe is a write

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Example:
 ```js
 fs.createReadStream('path/to/archive.zip')
   .pipe(unzipper.ParseOne())
-  .pipe(fs.createReadStream('firstFile.txt'));
+  .pipe(fs.createWriteStream('firstFile.txt'));
 ```
 
 ### Buffering the content of an entry into memory


### PR DESCRIPTION
The last pipe in the parseOne example must be a createWriteStream otherwise I am not sure to understand the example.

Thanks for the great library, works perfectly :)