### PR TITLE
Fix parsing zip64 extra field

### DIFF
--- a/lib/parseExtraField.js
+++ b/lib/parseExtraField.js
@@ -6,19 +6,25 @@ module.exports = function(extraField, vars) {
   while(!extra && extraField && extraField.length) {
     var candidateExtra = binary.parse(extraField)
       .word16lu('signature')
-      .word16lu('partsize')
-      .word64lu('uncompressedSize')
-      .word64lu('compressedSize')
-      .word64lu('offset')
-      .word64lu('disknum')
-      .vars;
+      .word16lu('partsize');
 
-    if(candidateExtra.signature === 0x0001) {
-      extra = candidateExtra;
+    if(candidateExtra.vars.signature === 0x0001) {
+      // the fields MUST only appear if the corresponding
+      // Local or Central directory record field is set to 0xFFFF or 0xFFFFFFFF
+      if (vars.uncompressedSize === 0xffffffff)
+        candidateExtra.word64lu('uncompressedSize');
+      if (vars.compressedSize === 0xffffffff)
+        candidateExtra.word64lu('compressedSize');
+      if (vars.offsetToLocalFileHeader === 0xffffffff)
+        candidateExtra.word64lu('offset');
+      if (vars.diskNumber === 0xffff)
+        candidateExtra.word32lu('disknum');
+
+      extra = candidateExtra.vars;
     } else {
       // Advance the buffer to the next part.
       // The total size of this part is the 4 byte header + partsize.
-      extraField = extraField.slice(candidateExtra.partsize + 4);
+      extraField = extraField.slice(candidateExtra.vars.partsize + 4);
     }
   }
 


### PR DESCRIPTION
Hello,

fields can be omitted in the zip64 extra field, see https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT, 4.5.3.

Thank you for great work!