### PR TITLE
Fix default concurrency to 1

### DIFF
--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -173,7 +173,7 @@ module.exports = function centralDirectory(source, options) {
                 .on('close',resolve)
                 .on('error',reject);
             });
-          }, opts.concurrency > 1 ? {concurrency: opts.concurrency || undefined} : undefined);
+          }, { concurrency: opts.concurrency > 1 ? opts.concurrency : 1 });
         });
       };
 


### PR DESCRIPTION
According to the documentation [here](https://github.com/ZJONSSON/node-unzipper#openmethodextract), for `Open.[method].extract()` the default value of `concurrency` should be `1`. 
In the code was set to `undefined` and as consequence it was extracting in parallel.

This also should fix the build on node v0.10 regarding `extractFromUrl` test.
It looks like that node version has some problems with too many parallel requests.