### PR TITLE
Add custom source option for Open

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,9 @@ async function main() {
   // ...
 }
 
+main();
+```
+
 ### Open.custom(source, [options])
 This function can be used to provide a custom source implementation. The source parameter expects a `stream` and a `size` function to be implemented. The size function should return a `Promise` that resolves the total size of the file. The stream function should return a chunk of a `Readable` stream given the offset and length parameters.
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ main();
 ```
 
 ### Open.custom(source, [options])
-This function can be used to provide a custom source implementation. The source parameter expects a `stream` and a `size` function to be implemented. The size function should return a `Promise` that resolves the total size of the file. The stream function should return a chunk of a `Readable` stream given the offset and length parameters.
+This function can be used to provide a custom source implementation. The source parameter expects a `stream` and a `size` function to be implemented. The size function should return a `Promise` that resolves the total size of the file. The stream function should return a `Readable` stream according to the supplied offset and length parameters.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,35 @@ async function main() {
   // ...
 }
 
+### Open.custom(source, [options])
+This function can be used to provide a custom source implementation. The source parameter expects a `stream` and a `size` function to be implemented. The size function should return a `Promise` that resolves the total size of the file. The stream function should return a chunk of a `Readable` stream given the offset and length parameters.
+
+Example:
+
+```js
+// Custom source implementation for reading a file from disk
+const customSource = {
+  stream: function(offset,length) {
+    return fs.createReadStream(archive, {start: offset, end: length && offset+length});
+  },
+  size: function() {
+    return new Promise(function(resolve, reject) {
+      fs.stat(archive, function(err, d) {
+        if (err)
+          reject(err);
+        else
+          resolve(d.size);
+      });
+    });
+  }
+};
+
+async function main() {
+  const directory = await unzipper.Open.custom(customSource);
+  console.log('directory', directory);
+  // ...
+}
+
 main();
 ```
 

--- a/lib/Open/index.js
+++ b/lib/Open/index.js
@@ -93,5 +93,9 @@ module.exports = {
     };
 
     return directory(source, options);
+  },
+
+  custom: function(source, options) {
+    return directory(source, options);
   }
 };

--- a/test/openCustom.js
+++ b/test/openCustom.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var test = require('tap').test;
+var fs = require('fs');
+var path = require('path');
+var unzip = require('../unzip');
+var Promise = require('bluebird');
+
+test("get content of a single file entry out of a zip", function (t) {
+  var archive = path.join(__dirname, '../testData/compressed-standard/archive.zip');
+
+  var customSource = {
+    stream: function(offset,length) {
+      return fs.createReadStream(archive, {start: offset, end: length && offset+length});
+    },
+    size: function() {
+      return new Promise(function(resolve, reject) {
+        fs.stat(archive, function(err, d) {
+          if (err)
+            reject(err);
+          else
+            resolve(d.size);
+        });
+      });
+    }
+  };
+
+  return unzip.Open.custom(customSource)
+    .then(function(d) {
+      var file = d.files.filter(function(file) {
+        return file.path == 'file.txt';
+      })[0];
+
+      return file.buffer()
+        .then(function(str) {
+          var fileStr = fs.readFileSync(path.join(__dirname, '../testData/compressed-standard/inflated/file.txt'), 'utf8');
+          t.equal(str.toString(), fileStr);
+          t.end();
+        });
+    });
+});


### PR DESCRIPTION
I've added a new function to `Open` that enables users to provide their own `source` implementation. This, for example, enables users to use Google Cloud Storage (example in the readme), Azure or maybe a different S3 implementation (the reason I'm making this change).

Fixes #199