### PR TITLE
Fixed broken unicode checks

### DIFF
--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -205,7 +205,7 @@ module.exports = function centralDirectory(source, options) {
         return records.pull(vars.fileNameLength).then(function(fileNameBuffer) {
           vars.pathBuffer = fileNameBuffer;
           vars.path = fileNameBuffer.toString('utf8');
-          vars.isUnicode = vars.flags & 0x11;
+          vars.isUnicode = (vars.flags & 0x800) != 0;
           return records.pull(vars.extraFieldLength);
         })
         .then(function(extraField) {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -130,7 +130,7 @@ Parse.prototype._readFile = function () {
       entry.props.path = fileName;
       entry.props.pathBuffer = fileNameBuffer;
       entry.props.flags = {
-        "isUnicode": vars.flags & 0x11
+        "isUnicode": (vars.flags & 0x800) != 0
       };
       entry.type = (vars.uncompressedSize === 0 && /[\/\\]$/.test(fileName)) ? 'Directory' : 'File';
 


### PR DESCRIPTION
I think you have missinterpreted "bit 11" as 0x11. It should be 0x800, though. According to the documentation they start with the LSB at index 0 and count up from there. So the bit indicating UTF-8 is the 12th bit, which is maskable by 0x800.
See [4.4.4 general purpose bit flag](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT)

Without this fix, the isUnicode flag is broken and essentially always zero.