### PR TITLE
Ensure Successful ZIP64 Extraction

### DIFF
--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -78,10 +78,9 @@ PullStream.prototype.stream = function(eof,includeEof) {
     }
     
     if (!done) {
-      if (self.finished && !this.__ended) {
+      if (self.finished) {
         self.removeListener('chunk',pull);
         self.emit('error', new Error('FILE_ENDED'));
-        this.__ended = true;
         return;
       }
       

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -51,16 +51,19 @@ Parse.prototype._readRecord = function () {
       return self._readFile();
     }
     else if (signature === 0x02014b50) {
-      self.__ended = true;
+      self.reachedCD = true;
       return self._readCentralDirectoryFileHeader();
     }
     else if (signature === 0x06054b50) {
       return self._readEndOfCentralDirectoryRecord();
     }
-    else if (self.__ended) {
-      return self.pull(endDirectorySignature).then(function() {
-          return self._readEndOfCentralDirectoryRecord();
-        });
+    else if (self.reachedCD) {
+      // _readEndOfCentralDirectoryRecord expects the EOCD
+      // signature to be consumed so set includeEof=true
+      var includeEof = true;
+      return self.pull(endDirectorySignature, includeEof).then(function() {
+        return self._readEndOfCentralDirectoryRecord();
+      });
     }
     else
       self.emit('error', new Error('invalid signature: 0x' + signature.toString(16)));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [

--- a/test/compressed-crx.js
+++ b/test/compressed-crx.js
@@ -56,8 +56,8 @@ test('open methods', function(t) {
   var tests = [
     {name: 'buffer',args: [buffer]},
     {name: 'file', args: [archive]},
-    {name: 'url', args: [request, 'https://s3.amazonaws.com/unzipper/archive.crx']},
-    {name: 's3', args: [s3, { Bucket: 'unzipper', Key: 'archive.crx'}]}
+    // {name: 'url', args: [request, 'https://s3.amazonaws.com/unzipper/archive.crx']},
+    // {name: 's3', args: [s3, { Bucket: 'unzipper', Key: 'archive.crx'}]}
   ];
 
   tests.forEach(function(test) {

--- a/test/openS3.js
+++ b/test/openS3.js
@@ -17,7 +17,7 @@ s3.headObject = function(params,cb) {
   return s3.makeUnauthenticatedRequest('headObject',params,cb);
 };
 
-test("get content of a single file entry out of a zip", function (t) {
+test("get content of a single file entry out of a zip", { skip: true }, function(t) {
   return unzip.Open.s3(s3,{ Bucket: 'unzipper', Key: 'archive.zip' })
     .then(function(d) {
       var file = d.files.filter(function(file) {

--- a/test/zip64.js
+++ b/test/zip64.js
@@ -5,6 +5,7 @@ var path = require('path');
 var unzip = require('../');
 var fs = require('fs');
 var Stream = require('stream');
+var temp = require('temp');
 
 var UNCOMPRESSED_SIZE = 5368709120;
 var ZIP64_OFFSET = 72;
@@ -76,8 +77,19 @@ t.test('Parse files from zip64 format correctly', function (t) {
       .pipe(unzip.Parse())
       .on('entry', function(entry) {
         t.same(entry.vars.uncompressedSize, ZIP64_SIZE, 'Parse: File header');
-        t.end();
-      });
+      })
+      .on('close', function() { t.end(); });
+  });
+
+  t.test('in unzipper.extract', function (t) {
+    temp.mkdir('node-unzip-', function (err, dirPath) {
+      if (err) {
+        throw err;
+      }
+      fs.createReadStream(archive)
+        .pipe(unzip.Extract({ path: dirPath }))
+        .on('close', function() { t.end(); });
+    });
   });
 
   t.end();  


### PR DESCRIPTION
## Fixed
* Correctly handle ZIP64 format in `unzipper.Extract` and `unzipper.Parse` by ensuring that the standard EOCD signature is consumed after seeking to it, preventing the EOCD read from being incorrectly offset by 4 bytes.
* Emit `FILE_ENDED` error from `PullStream` for any `pull` that goes beyond EOF whether we've reached the central directory (f.k.a. `self.__ended==true`) or not.

## Misc
* Commented/skipped tests that rely on an S3 bucket that no longer seems to be accessible.

Fixes #243 