### PR TITLE
Implement Open Handler for Google Cloud Storage / gcs

### DIFF
--- a/lib/Open/index.js
+++ b/lib/Open/index.js
@@ -95,6 +95,21 @@ module.exports = {
     return directory(source, options);
   },
 
+  gcs : function(client, params, options) {
+    const bucket = client.bucket(params.Bucket);
+    const file = bucket.file(params.Key);
+    var source = {
+      size: function() {
+        return file.getMetadata().then(([response]) => +response.size)
+      },
+      stream: function(offset,length) {
+        return file.createReadStream({ start: offset, end: length ? length : undefined })
+      }
+    };
+
+    return directory(source, options);
+  },
+
   custom: function(source, options) {
     return directory(source, options);
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "setimmediate": "~1.0.4"
   },
   "devDependencies": {
+    "@google-cloud/storage": "^5.16.1",
     "aws-sdk": "^2.77.0",
     "dirdiff": ">= 0.0.1 < 1",
     "iconv-lite": "^0.4.24",

--- a/test/openGcs.js
+++ b/test/openGcs.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var test = require('tap').test;
+var fs = require('fs');
+var path = require('path');
+var unzip = require('../');
+const { Storage } = require('@google-cloud/storage');
+const storage = new Storage();
+
+test("get content of a single file entry out of a zip", function (t) {
+  return unzip.Open.gcs(storage, { Bucket: 'unzipper', Key: 'archive.zip' }).then(function(d) {
+    var file = d.files.filter(function(file) {
+      return file.path == 'content.opf';
+    })[0];
+    return file.buffer().then(function(str) {
+      var fileStr = fs.readFileSync(path.join(__dirname, '../testData/compressed-standard/inflated/file.txt'), 'utf8');
+      t.equal(str.toString(), fileStr);
+      t.end();
+    });
+  });
+});


### PR DESCRIPTION
## Improvements

* Support `Open.gcs` for Google Cloud Storage, using the `@google-cloud/storage` npm package.

### Signature

```ts
unzip.Open.gcs(storage: Storage, params: { Bucket: string, Key: string })
```