### PR TITLE
Break the huge promise chain

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -36,48 +36,43 @@ function Parse(opts) {
 
 util.inherits(Parse, PullStream);
 
-Parse.prototype._readRecord = async function () {
+Parse.prototype._readRecord = function () {
   var self = this;
 
-  while(true) {
-    const data = await self.pull(4);
-
+  return self.pull(4).then(function(data) {
     if (data.length === 0)
       return;
 
     var signature = data.readUInt32LE(0);
 
     if (signature === 0x34327243) {
-      await self._readCrxHeader();
+      return self._readCrxHeader();
     }
     if (signature === 0x04034b50) {
-      const { fileSizeKnown, entry } = await self._readFile();
-
-      if(!fileSizeKnown) {
-        await self._processDataDescriptor(entry);
-      }
+      return self._readFile();
     }
     else if (signature === 0x02014b50) {
       self.reachedCD = true;
-      await self._readCentralDirectoryFileHeader();
+      return self._readCentralDirectoryFileHeader();
     }
     else if (signature === 0x06054b50) {
-      await self._readEndOfCentralDirectoryRecord();
-      return;
+      return self._readEndOfCentralDirectoryRecord();
     }
     else if (self.reachedCD) {
       // _readEndOfCentralDirectoryRecord expects the EOCD
       // signature to be consumed so set includeEof=true
       var includeEof = true;
-      await self.pull(endDirectorySignature, includeEof);
-      await self._readEndOfCentralDirectoryRecord();
-      return;
+      return self.pull(endDirectorySignature, includeEof).then(function() {
+        return self._readEndOfCentralDirectoryRecord();
+      });
     }
-    else {
+    else
       self.emit('error', new Error('invalid signature: 0x' + signature.toString(16)));
-      return;
+  }).then((function(loop) {
+    if(loop) {
+      return self._readRecord();
     }
-  }
+  }));
 };
 
 Parse.prototype._readCrxHeader = function() {
@@ -93,6 +88,7 @@ Parse.prototype._readCrxHeader = function() {
     self.crxHeader.publicKey = data.slice(0,self.crxHeader.pubKeyLength);
     self.crxHeader.signature = data.slice(self.crxHeader.pubKeyLength);
     self.emit('crx-header',self.crxHeader);
+    return true;
   });
 };
 
@@ -200,7 +196,7 @@ Parse.prototype._readFile = function () {
             .on('error',function(err) { self.emit('error',err);})
             .pipe(entry)
             .on('finish', function() {
-              resolve({ fileSizeKnown, entry });
+              return fileSizeKnown ? resolve(fileSizeKnown) : self._processDataDescriptor(entry).then(resolve).catch(reject);
             });
         });
       });
@@ -219,6 +215,7 @@ Parse.prototype._processDataDescriptor = function (entry) {
       .vars;
 
     entry.size = vars.uncompressedSize;
+    return true;
   });
 };
 
@@ -251,6 +248,9 @@ Parse.prototype._readCentralDirectoryFileHeader = function () {
     })
     .then(function(extraField) {
       return self.pull(vars.fileCommentLength);
+    })
+    .then(function(fileComment) {
+      return true;
     });
   });
 };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -36,38 +36,48 @@ function Parse(opts) {
 
 util.inherits(Parse, PullStream);
 
-Parse.prototype._readRecord = function () {
+Parse.prototype._readRecord = async function () {
   var self = this;
-  return self.pull(4).then(function(data) {
+
+  while(true) {
+    const data = await self.pull(4);
+
     if (data.length === 0)
       return;
 
     var signature = data.readUInt32LE(0);
 
     if (signature === 0x34327243) {
-      return self._readCrxHeader();
+      await self._readCrxHeader();
     }
     if (signature === 0x04034b50) {
-      return self._readFile();
+      const { fileSizeKnown, entry } = await self._readFile();
+
+      if(!fileSizeKnown) {
+        await self._processDataDescriptor(entry);
+      }
     }
     else if (signature === 0x02014b50) {
       self.reachedCD = true;
-      return self._readCentralDirectoryFileHeader();
+      await self._readCentralDirectoryFileHeader();
     }
     else if (signature === 0x06054b50) {
-      return self._readEndOfCentralDirectoryRecord();
+      await self._readEndOfCentralDirectoryRecord();
+      return;
     }
     else if (self.reachedCD) {
       // _readEndOfCentralDirectoryRecord expects the EOCD
       // signature to be consumed so set includeEof=true
       var includeEof = true;
-      return self.pull(endDirectorySignature, includeEof).then(function() {
-        return self._readEndOfCentralDirectoryRecord();
-      });
+      await self.pull(endDirectorySignature, includeEof);
+      await self._readEndOfCentralDirectoryRecord();
+      return;
     }
-    else
+    else {
       self.emit('error', new Error('invalid signature: 0x' + signature.toString(16)));
-  });
+      return;
+    }
+  }
 };
 
 Parse.prototype._readCrxHeader = function() {
@@ -83,7 +93,6 @@ Parse.prototype._readCrxHeader = function() {
     self.crxHeader.publicKey = data.slice(0,self.crxHeader.pubKeyLength);
     self.crxHeader.signature = data.slice(self.crxHeader.pubKeyLength);
     self.emit('crx-header',self.crxHeader);
-    return self._readRecord();
   });
 };
 
@@ -191,9 +200,7 @@ Parse.prototype._readFile = function () {
             .on('error',function(err) { self.emit('error',err);})
             .pipe(entry)
             .on('finish', function() {
-              return fileSizeKnown ?
-                self._readRecord().then(resolve).catch(reject) :
-                self._processDataDescriptor(entry).then(resolve).catch(reject);
+              resolve({ fileSizeKnown, entry });
             });
         });
       });
@@ -212,7 +219,6 @@ Parse.prototype._processDataDescriptor = function (entry) {
       .vars;
 
     entry.size = vars.uncompressedSize;
-    return self._readRecord();
   });
 };
 
@@ -245,9 +251,6 @@ Parse.prototype._readCentralDirectoryFileHeader = function () {
     })
     .then(function(extraField) {
       return self.pull(vars.fileCommentLength);
-    })
-    .then(function(fileComment) {
-      return self._readRecord();
     });
   });
 };


### PR DESCRIPTION
By keeping the steps in the main promise in `_readRecord` less nested, we  avoid the issue documented in #254 where the promise chain ends up taking up all the memory of an application.

In short, we allow the garbage collector to collect the small promises as they resolve, so their variables do not remain in scope, rather than building one huge chain that keeps references to the future "then"s and can never resolve as it is always waiting for something else.

The first commit contains my naïve solution using async/await syntax. I fix this in the second commit, so we avoid that. It is there for explanatory purposes.

I suggest using a squash and merge when merging this in.