### PR TITLE
Drop node 0.8 support

### DIFF
--- a/lib/Open/unzip.js
+++ b/lib/Open/unzip.js
@@ -16,7 +16,9 @@ module.exports = function unzip(source,offset,_password, directoryVars) {
   var file = PullStream(),
       entry = Stream.PassThrough();
 
-  var req = source.stream(offset);
+  var EOF_LEN = 4;
+  var FIXED_HEADER_LEN = 30;
+  var req = source.stream(offset, directoryVars.compressedSize ? directoryVars.compressedSize + directoryVars.fileNameLength + directoryVars.extraFieldLength + EOF_LEN + FIXED_HEADER_LEN : undefined);
   req.pipe(file).on('error', function(e) {
     entry.emit('error', e);
   });
@@ -106,7 +108,9 @@ module.exports = function unzip(source,offset,_password, directoryVars) {
         .on('error',function(err) { entry.emit('error',err);})
         .pipe(entry)
         .on('finish', function() {
-          if (req.abort)
+          if (req.end)
+            req.end();
+          else if (req.abort)
             req.abort();
           else if (req.close)
             req.close();

--- a/package.json
+++ b/package.json
@@ -26,13 +26,10 @@
     "big-integer": "^1.6.17",
     "binary": "~0.3.0",
     "bluebird": "~3.4.1",
-    "buffer-indexof-polyfill": "~1.0.0",
     "duplexer2": "~0.1.4",
     "fstream": "^1.0.12",
     "graceful-fs": "^4.2.2",
-    "listenercount": "~1.0.1",
     "readable-stream": "~2.3.6",
-    "setimmediate": "~1.0.4"
   },
   "devDependencies": {
     "aws-sdk": "^2.77.0",

--- a/unzip.js
+++ b/unzip.js
@@ -1,9 +1,4 @@
 'use strict';
-// Polyfills for node 0.8
-require('listenercount');
-require('buffer-indexof-polyfill');
-require('setimmediate');
-
 
 exports.Parse = require('./lib/parse');
 exports.ParseOne = require('./lib/parseOne');


### PR DESCRIPTION
`buffer-indexof-polyfill` uses `new Buffer()` and causes a bunch of deprecation warnings - get rid of it