### PR TITLE
fix .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@ test/
 testData/
 .nyc_output/
 coverage/
+.tap/
+.github/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [


### PR DESCRIPTION
In previous version the resulting `.tap` coverage files were included in the published package.