### PR TITLE
Open methods - only stream up to length

### DIFF
--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -215,7 +215,13 @@ module.exports = function centralDirectory(source, options) {
           vars.comment = comment;
           vars.type = (vars.uncompressedSize === 0 && /[\/\\]$/.test(vars.path)) ? 'Directory' : 'File';
           vars.stream = function(_password) {
-            return unzip(source, vars.offsetToLocalFileHeader,_password, vars);
+            var totalSize = 30
+              + 10 // add an extra buffer
+              + (vars.extraFieldLength || 0) 
+              + (vars.fileNameLength || 0)
+              + vars.compressedSize;
+
+            return unzip(source, vars.offsetToLocalFileHeader,_password, vars, totalSize);
           };
           vars.buffer = function(_password) {
             return BufferStream(vars.stream(_password));

--- a/lib/Open/index.js
+++ b/lib/Open/index.js
@@ -8,7 +8,8 @@ module.exports = {
     var source = {
       stream: function(offset, length) {
         var stream = Stream.PassThrough();
-        stream.end(buffer.slice(offset, length));
+        var end = length ? offset + length : undefined;
+        stream.end(buffer.slice(offset, end));
         return stream;
       },
       size: function() {
@@ -19,8 +20,9 @@ module.exports = {
   },
   file: function(filename, options) {
     var source = {
-      stream: function(offset,length) {
-        return fs.createReadStream(filename,{start: offset, end: length && offset+length});
+      stream: function(start,length) {
+        var end = length ? start + length : undefined;
+        return fs.createReadStream(filename,{start, end});
       },
       size: function() {
         return new Promise(function(resolve,reject) {
@@ -46,8 +48,9 @@ module.exports = {
     var source = {
       stream : function(offset,length) {
         var options = Object.create(params);
+        var end = length ? offset + length : '';
         options.headers = Object.create(params.headers);
-        options.headers.range = 'bytes='+offset+'-' + (length ? length : '');
+        options.headers.range = 'bytes='+offset+'-' + end;
         return request(options);
       },
       size: function() {
@@ -83,7 +86,8 @@ module.exports = {
         var d = {};
         for (var key in params)
           d[key] = params[key];
-        d.Range = 'bytes='+offset+'-' + (length ? length : '');
+        var end = length ? offset + length : '';
+        d.Range = 'bytes='+offset+'-' + end;
         return client.getObject(d).createReadStream();
       }
     };

--- a/lib/Open/unzip.js
+++ b/lib/Open/unzip.js
@@ -7,11 +7,11 @@ var parseExtraField = require('../parseExtraField');
 var parseDateTime = require('../parseDateTime');
 var parseBuffer = require('../parseBuffer');
 
-module.exports = function unzip(source,offset,_password, directoryVars) {
+module.exports = function unzip(source, offset, _password, directoryVars, length) {
   var file = PullStream(),
       entry = Stream.PassThrough();
 
-  var req = source.stream(offset);
+  var req = source.stream(offset, length);
   req.pipe(file).on('error', function(e) {
     entry.emit('error', e);
   });

--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -46,7 +46,7 @@ PullStream.prototype.stream = function(eof,includeEof) {
         packet = self.buffer.slice(0,eof);
         self.buffer = self.buffer.slice(eof);
         eof -= packet.length;
-        done = !eof;
+        done = done || !eof;
       } else {
         var match = self.buffer.indexOf(eof);
         if (match !== -1) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [


### PR DESCRIPTION
The stream method under the `Open` method did not utilize the fact that we know the size of the individual compressed file and, therefore, can avoid having the stream unbounded, reducing I/O.   

Each entry comprises the local file header followed by the compressed file content.   The size of the local header is dynamic; the base variables are 30 bytes, but then we have a dynamically sized filename and extra field.   For some reason, I have to add a small buffer on top (a few bytes) to get all test cases passing.

Local file header (source [Wikipedia](https://en.wikipedia.org/wiki/ZIP_(file_format)))
![image](https://github.com/ZJONSSON/node-unzipper/assets/1082488/b697a5a2-85c1-405b-b841-77d1d06dfd35)

Thanks to @jpambrun for catching this.  Closes https://github.com/ZJONSSON/node-unzipper/issues/308