### PR TITLE
Update docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.11.6",
+  "version": "0.12.0",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [


### PR DESCRIPTION
The `Open` methods should be the primary way to use this library and the docs should reflect that