### PR TITLE
Add support for @aws-sdk version 3

### DIFF
--- a/lib/Open/index.js
+++ b/lib/Open/index.js
@@ -1,100 +1,98 @@
-const fs = require('graceful-fs');
-const directory = require('./directory');
-const Stream = require('stream');
-const { GetObjectCommand, HeadObjectCommand } = require('@aws-sdk/client-s3');
+const fs = require("graceful-fs");
+const directory = require("./directory");
+const Stream = require("stream");
 
 module.exports = {
-  buffer: function(buffer, options) {
+  buffer: function (buffer, options) {
     const source = {
-      stream: function(offset, length) {
+      stream: function (offset, length) {
         const stream = Stream.PassThrough();
         const end = length ? offset + length : undefined;
         stream.end(buffer.slice(offset, end));
         return stream;
       },
-      size: function() {
+      size: function () {
         return Promise.resolve(buffer.length);
-      }
+      },
     };
     return directory(source, options);
   },
-  file: function(filename, options) {
+  file: function (filename, options) {
     const source = {
-      stream: function(start, length) {
+      stream: function (start, length) {
         const end = length ? start + length : undefined;
-        return fs.createReadStream(filename, {start, end});
+        return fs.createReadStream(filename, { start, end });
       },
-      size: function() {
-        return new Promise(function(resolve, reject) {
-          fs.stat(filename, function(err, d) {
-            if (err)
-              reject(err);
-            else
-              resolve(d.size);
+      size: function () {
+        return new Promise(function (resolve, reject) {
+          fs.stat(filename, function (err, d) {
+            if (err) reject(err);
+            else resolve(d.size);
           });
         });
-      }
+      },
     };
     return directory(source, options);
   },
 
-  url: function(request, params, options) {
-    if (typeof params === 'string')
-      params = {url: params};
-    if (!params.url)
-      throw 'URL missing';
+  url: function (request, params, options) {
+    if (typeof params === "string") params = { url: params };
+    if (!params.url) throw "URL missing";
     params.headers = params.headers || {};
 
     const source = {
-      stream : function(offset, length) {
+      stream: function (offset, length) {
         const options = Object.create(params);
-        const end = length ? offset + length : '';
+        const end = length ? offset + length : "";
         options.headers = Object.create(params.headers);
-        options.headers.range = 'bytes='+offset+'-' + end;
+        options.headers.range = "bytes=" + offset + "-" + end;
         return request(options);
       },
-      size: function() {
-        return new Promise(function(resolve, reject) {
+      size: function () {
+        return new Promise(function (resolve, reject) {
           const req = request(params);
-          req.on('response', function(d) {
-            req.abort();
-            if (!d.headers['content-length'])
-              reject(new Error('Missing content length header'));
-            else
-              resolve(d.headers['content-length']);
-          }).on('error', reject);
+          req
+            .on("response", function (d) {
+              req.abort();
+              if (!d.headers["content-length"])
+                reject(new Error("Missing content length header"));
+              else resolve(d.headers["content-length"]);
+            })
+            .on("error", reject);
         });
-      }
+      },
     };
 
     return directory(source, options);
   },
 
-  s3 : function(client, params, options) {
+  s3: function (client, params, options) {
     const source = {
-      size: function() {
-        return new Promise(function(resolve, reject) {
-          client.headObject(params, function(err, d) {
-            if (err)
-              reject(err);
-            else
-              resolve(d.ContentLength);
+      size: function () {
+        return new Promise(function (resolve, reject) {
+          client.headObject(params, function (err, d) {
+            if (err) reject(err);
+            else resolve(d.ContentLength);
           });
         });
       },
-      stream: function(offset, length) {
+      stream: function (offset, length) {
         const d = {};
-        for (const key in params)
-          d[key] = params[key];
-        const end = length ? offset + length : '';
-        d.Range = 'bytes='+offset+'-' + end;
+        for (const key in params) d[key] = params[key];
+        const end = length ? offset + length : "";
+        d.Range = "bytes=" + offset + "-" + end;
         return client.getObject(d).createReadStream();
-      }
+      },
     };
 
     return directory(source, options);
   },
   s3_v3: function (client, params, options) {
+    const {
+      GetObjectCommand,
+      HeadObjectCommand,
+    } = require("@aws-sdk/client-s3");
+
     const source = {
       size: async () => {
         const head = await client.send(
@@ -130,7 +128,7 @@ module.exports = {
 
     return directory(source, options);
   },
-  custom: function(source, options) {
+  custom: function (source, options) {
     return directory(source, options);
-  }
+  },
 };

--- a/lib/Open/index.js
+++ b/lib/Open/index.js
@@ -1,7 +1,6 @@
 const fs = require('graceful-fs');
 const directory = require('./directory');
 const Stream = require('stream');
-const { GetObjectCommand, HeadObjectCommand } = require('@aws-sdk/client-s3');
 
 module.exports = {
   buffer: function(buffer, options) {
@@ -95,6 +94,7 @@ module.exports = {
     return directory(source, options);
   },
   s3_v3: function (client, params, options) {
+    const { GetObjectCommand, HeadObjectCommand } = require('@aws-sdk/client-s3');
     const source = {
       size: async () => {
         const head = await client.send(
@@ -104,7 +104,11 @@ module.exports = {
           })
         );
 
-        return head.ContentLength ?? 0;
+        if(!head.ContentLength) {
+          return 0;
+        }
+
+        return head.ContentLength;
       },
       stream: (offset, length) => {
         const stream = Stream.PassThrough();

--- a/lib/Open/index.js
+++ b/lib/Open/index.js
@@ -1,6 +1,7 @@
 const fs = require('graceful-fs');
 const directory = require('./directory');
 const Stream = require('stream');
+const { GetObjectCommand, HeadObjectCommand } = require('@aws-sdk/client-s3');
 
 module.exports = {
   buffer: function(buffer, options) {
@@ -93,7 +94,42 @@ module.exports = {
 
     return directory(source, options);
   },
+  s3_v3: function (client, params, options) {
+    const source = {
+      size: async () => {
+        const head = await client.send(
+          new HeadObjectCommand({
+            Bucket: params.Bucket,
+            Key: params.Key,
+          })
+        );
 
+        return head.ContentLength ?? 0;
+      },
+      stream: (offset, length) => {
+        const stream = Stream.PassThrough();
+        const end = length ? offset + length : "";
+        client
+          .send(
+            new GetObjectCommand({
+              Bucket: params.Bucket,
+              Key: params.Key,
+              Range: `bytes=${offset}-${end}`,
+            })
+          )
+          .then((response) => {
+            response.Body.pipe(stream);
+          })
+          .catch((error) => {
+            stream.emit("error", error);
+          });
+
+        return stream;
+      },
+    };
+
+    return directory(source, options);
+  },
   custom: function(source, options) {
     return directory(source, options);
   }

--- a/lib/Open/index.js
+++ b/lib/Open/index.js
@@ -1,98 +1,100 @@
-const fs = require("graceful-fs");
-const directory = require("./directory");
-const Stream = require("stream");
+const fs = require('graceful-fs');
+const directory = require('./directory');
+const Stream = require('stream');
+const { GetObjectCommand, HeadObjectCommand } = require('@aws-sdk/client-s3');
 
 module.exports = {
-  buffer: function (buffer, options) {
+  buffer: function(buffer, options) {
     const source = {
-      stream: function (offset, length) {
+      stream: function(offset, length) {
         const stream = Stream.PassThrough();
         const end = length ? offset + length : undefined;
         stream.end(buffer.slice(offset, end));
         return stream;
       },
-      size: function () {
+      size: function() {
         return Promise.resolve(buffer.length);
-      },
+      }
     };
     return directory(source, options);
   },
-  file: function (filename, options) {
+  file: function(filename, options) {
     const source = {
-      stream: function (start, length) {
+      stream: function(start, length) {
         const end = length ? start + length : undefined;
-        return fs.createReadStream(filename, { start, end });
+        return fs.createReadStream(filename, {start, end});
       },
-      size: function () {
-        return new Promise(function (resolve, reject) {
-          fs.stat(filename, function (err, d) {
-            if (err) reject(err);
-            else resolve(d.size);
+      size: function() {
+        return new Promise(function(resolve, reject) {
+          fs.stat(filename, function(err, d) {
+            if (err)
+              reject(err);
+            else
+              resolve(d.size);
           });
         });
-      },
+      }
     };
     return directory(source, options);
   },
 
-  url: function (request, params, options) {
-    if (typeof params === "string") params = { url: params };
-    if (!params.url) throw "URL missing";
+  url: function(request, params, options) {
+    if (typeof params === 'string')
+      params = {url: params};
+    if (!params.url)
+      throw 'URL missing';
     params.headers = params.headers || {};
 
     const source = {
-      stream: function (offset, length) {
+      stream : function(offset, length) {
         const options = Object.create(params);
-        const end = length ? offset + length : "";
+        const end = length ? offset + length : '';
         options.headers = Object.create(params.headers);
-        options.headers.range = "bytes=" + offset + "-" + end;
+        options.headers.range = 'bytes='+offset+'-' + end;
         return request(options);
       },
-      size: function () {
-        return new Promise(function (resolve, reject) {
+      size: function() {
+        return new Promise(function(resolve, reject) {
           const req = request(params);
-          req
-            .on("response", function (d) {
-              req.abort();
-              if (!d.headers["content-length"])
-                reject(new Error("Missing content length header"));
-              else resolve(d.headers["content-length"]);
-            })
-            .on("error", reject);
+          req.on('response', function(d) {
+            req.abort();
+            if (!d.headers['content-length'])
+              reject(new Error('Missing content length header'));
+            else
+              resolve(d.headers['content-length']);
+          }).on('error', reject);
         });
-      },
+      }
     };
 
     return directory(source, options);
   },
 
-  s3: function (client, params, options) {
+  s3 : function(client, params, options) {
     const source = {
-      size: function () {
-        return new Promise(function (resolve, reject) {
-          client.headObject(params, function (err, d) {
-            if (err) reject(err);
-            else resolve(d.ContentLength);
+      size: function() {
+        return new Promise(function(resolve, reject) {
+          client.headObject(params, function(err, d) {
+            if (err)
+              reject(err);
+            else
+              resolve(d.ContentLength);
           });
         });
       },
-      stream: function (offset, length) {
+      stream: function(offset, length) {
         const d = {};
-        for (const key in params) d[key] = params[key];
-        const end = length ? offset + length : "";
-        d.Range = "bytes=" + offset + "-" + end;
+        for (const key in params)
+          d[key] = params[key];
+        const end = length ? offset + length : '';
+        d.Range = 'bytes='+offset+'-' + end;
         return client.getObject(d).createReadStream();
-      },
+      }
     };
 
     return directory(source, options);
   },
   s3_v3: function (client, params, options) {
-    const {
-      GetObjectCommand,
-      HeadObjectCommand,
-    } = require("@aws-sdk/client-s3");
-
     const source = {
       size: async () => {
         const head = await client.send(
@@ -128,7 +130,7 @@ module.exports = {
 
     return directory(source, options);
   },
-  custom: function (source, options) {
+  custom: function(source, options) {
     return directory(source, options);
-  },
+  }
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "tap": "^12.7.0",
     "temp": ">= 0.4.0 < 1"
   },
-  "peerDependencies": {
+  "optionalDependencies": {
     "@aws-sdk/client-s3": "^3.0.0"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "tap": "^12.7.0",
     "temp": ">= 0.4.0 < 1"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@aws-sdk/client-s3": "^3.0.0"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "iconv-lite": "^0.4.24",
     "request": "^2.88.0",
     "stream-buffers": ">= 0.2.5 < 1",
-    "tap": "^12.7.0",
+    "tap": "^16.3.10",
     "temp": ">= 0.4.0 < 1"
   },
   "peerDependencies": {
@@ -60,6 +60,6 @@
   ],
   "main": "unzip.js",
   "scripts": {
-    "test": "npx tap test/*.js --coverage-report=html --reporter=dot"
+    "test": "npx tap@^16.3.10 test/*.js --no-coverage --reporter=dot"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@eslint/js": "^9.2.0",
     "aws-sdk": "^2.1636.0",
+    "@aws-sdk/client-s3": "^3.0.0",
     "dirdiff": ">= 0.0.1 < 1",
     "eslint": "^9.2.0",
     "globals": "^15.2.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "tap": "^12.7.0",
     "temp": ">= 0.4.0 < 1"
   },
+  "peerDependencies": {
+    "@aws-sdk/client-s3": "^3.0.0"
+  },
   "directories": {
     "example": "examples",
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -42,9 +42,6 @@
     "tap": "^16.3.10",
     "temp": ">= 0.4.0 < 1"
   },
-  "peerDependencies": {
-    "@aws-sdk/client-s3": "^3.0.0"
-  },
   "directories": {
     "example": "examples",
     "test": "test"
@@ -60,6 +57,6 @@
   ],
   "main": "unzip.js",
   "scripts": {
-    "test": "npx tap@^16.3.10 test/*.js --no-coverage --reporter=dot"
+    "test": "npx tap test/*.js --coverage-report=html --lines=90 --functions=85 --statements=90 --branches=80 --reporter=dot"
   }
 }

--- a/test/openS3_v3.js
+++ b/test/openS3_v3.js
@@ -1,0 +1,25 @@
+const test = require('tap').test;
+const fs = require('fs');
+const path = require('path');
+const unzip = require('../unzip');
+
+const version = +process.version.replace('v', '').split('.')[0];
+
+test("get content of a single file entry out of a zip", { skip: version < 16 }, function(t) {
+  const { S3Client } = require('@aws-sdk/client-s3');
+  const client = new S3Client({ region: 'us-east-1' });
+
+  return unzip.Open.s3_v3(client, { Bucket: 'unzipper', Key: 'archive.zip' })
+    .then(function(d) {
+      const file = d.files.filter(function(file) {
+        return file.path == 'file.txt';
+      })[0];
+
+      return file.buffer()
+        .then(function(str) {
+          const fileStr = fs.readFileSync(path.join(__dirname, '../testData/compressed-standard/inflated/file.txt'), 'utf8');
+          t.equal(str.toString(), fileStr);
+          t.end();
+        });
+    });
+});

--- a/test/openS3_v3.js
+++ b/test/openS3_v3.js
@@ -1,25 +1,35 @@
-const test = require('tap').test;
-const fs = require('fs');
-const path = require('path');
-const unzip = require('../unzip');
+const test = require("tap").test;
+const unzip = require("../unzip");
 
-const version = +process.version.replace('v', '').split('.')[0];
+const version = +process.version.replace("v", "").split(".")[0];
 
-test("get content of a single file entry out of a zip", { skip: version < 16 }, function(t) {
-  const { S3Client } = require('@aws-sdk/client-s3');
-  const client = new S3Client({ region: 'us-east-1' });
+test(
+  "get content of a single file entry out of a zip",
+  { skip: version < 16 },
+  function (t) {
+    const { S3Client } = require("@aws-sdk/client-s3");
 
-  return unzip.Open.s3_v3(client, { Bucket: 'unzipper', Key: 'archive.zip' })
-    .then(function(d) {
-      const file = d.files.filter(function(file) {
-        return file.path == 'file.txt';
+    const client = new S3Client({
+      region: "us-east-1",
+      signer: { sign: async (request) => request },
+    });
+
+    // These files are provided by AWS's open data registry project.
+    // https://github.com/awslabs/open-data-registry
+
+    return unzip.Open.s3_v3(client, {
+      Bucket: "wikisum",
+      Key: "WikiSumDataset.zip",
+    }).then(function (d) {
+      const file = d.files.filter(function (file) {
+        return file.path == "WikiSumDataset/LICENSE.txt";
       })[0];
 
-      return file.buffer()
-        .then(function(str) {
-          const fileStr = fs.readFileSync(path.join(__dirname, '../testData/compressed-standard/inflated/file.txt'), 'utf8');
-          t.equal(str.toString(), fileStr);
-          t.end();
-        });
+      return file.buffer().then(function (b) {
+        const firstLine = b.toString().split("\n")[0];
+        t.equal(firstLine, "Attribution-NonCommercial-ShareAlike 3.0 Unported");
+        t.end();
+      });
     });
-});
+  }
+);


### PR DESCRIPTION
This should resolve this issue: https://github.com/ZJONSSON/node-unzipper/issues/241 

I have used a variation of @Sljux's solution to make the interface compatible with the current `stream` interface.

I've chosen to make the v3 interface a completely separate method... the two clients are different enough that I think it makes sense to break them into two different paths. I can merge them under one function call if people would prefer that. 