### PR TITLE
Add ts-ignore to dynamic require

### DIFF
--- a/lib/Open/index.js
+++ b/lib/Open/index.js
@@ -94,6 +94,7 @@ module.exports = {
     return directory(source, options);
   },
   s3_v3: function (client, params, options) {
+    //@ts-ignore
     const { GetObjectCommand, HeadObjectCommand } = require('@aws-sdk/client-s3');
     const source = {
       size: async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unzipper",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Unzip cross-platform streaming API ",
   "author": "Evan Oxfeld <eoxfeld@gmail.com>",
   "contributors": [


### PR DESCRIPTION
Unzipper is designed to be a small library and therefore does not include by default various clients for external integrations, such as the request library and the aws sdk.    In most methods the "client" has to be passed into the respective function as an argument, but with aws_v3 we need multiple functions from the library, so it is "required" dynamically, but only when you call the aws_s3 function directly.  (which means you have to separately

The dynamic require however seems to cause problems with type checking with some combination of `tsc` and `ts-loader` at the compilation stage (this is not a runtime error).

