### PR TITLE
fix data descriptor handling

### DIFF
--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -29,6 +29,8 @@ PullStream.prototype._write = function(chunk, e, cb) {
 PullStream.prototype.stream = function(eof, includeEof) {
   const p = Stream.PassThrough();
   let done;
+  let consumedLength = 0;
+
   const self = this;
   const DATA_DESCRIPTOR_SIGNATURE = Buffer.alloc(4);
   DATA_DESCRIPTOR_SIGNATURE.writeUInt32LE(0x08074b50, 0);
@@ -42,17 +44,16 @@ PullStream.prototype.stream = function(eof, includeEof) {
   }
 
   function getDataDescriptorIndex(startIndex) {
-    const match = self.buffer.indexOf(DATA_DESCRIPTOR_SIGNATURE, startIndex);
-    if (match !== -1) {
-      if (self.buffer.length >= match + 12) {
-        const intBytes = self.buffer.slice(match + 8, match + 12); // 8 bytes after the data descriptor signature is the size of the compressed file.
-        const intValue = intBytes.readUInt16LE(0);
+    const matchedIndex = self.buffer.indexOf(DATA_DESCRIPTOR_SIGNATURE, startIndex);
+    if (matchedIndex !== -1) {
+      if (self.buffer.length >= matchedIndex + 12) {
+        const compressedSize = self.buffer.readUInt32LE(matchedIndex + 8); // 8 bytes after the data descriptor signature is the size of the compressed file.
 
-        if (intValue === match) {
-          return match;
+        if (compressedSize === matchedIndex + consumedLength) {
+          return matchedIndex;
         } else {
           // Not a data descriptor signature for this buffer, so search after it.
-          return getDataDescriptorIndex(match + 1);
+          return getDataDescriptorIndex(matchedIndex + 1);
         }
       }
     }
@@ -65,22 +66,24 @@ PullStream.prototype.stream = function(eof, includeEof) {
       if (typeof eof === 'number') {
         packet = self.buffer.slice(0, eof);
         self.buffer = self.buffer.slice(eof);
+        consumedLength += packet.length;
         eof -= packet.length;
         done = done || !eof;
       } else {
-        let match = -1;
+        let matchedIndex = -1;
         if (DATA_DESCRIPTOR_SIGNATURE.equals(eof)) {
-          match = getDataDescriptorIndex(0);
+          matchedIndex = getDataDescriptorIndex(0);
         } else {
-          match = self.buffer.indexOf(eof);
+          matchedIndex = self.buffer.indexOf(eof);
         }
-        if (match !== -1) {
+        if (matchedIndex !== -1) {
           // store signature match byte offset to allow us to reference
           // this for zip64 offset
-          self.match = match;
-          if (includeEof) match = match + eof.length;
-          packet = self.buffer.slice(0, match);
-          self.buffer = self.buffer.slice(match);
+          self.match = matchedIndex;
+          if (includeEof) matchedIndex = matchedIndex + eof.length;
+          packet = self.buffer.slice(0, matchedIndex);
+          self.buffer = self.buffer.slice(matchedIndex);
+          consumedLength += packet.length;
           done = true;
         } else {
           const len = self.buffer.length - eof.length;
@@ -89,6 +92,7 @@ PullStream.prototype.stream = function(eof, includeEof) {
           } else {
             packet = self.buffer.slice(0, len);
             self.buffer = self.buffer.slice(len);
+            consumedLength += packet.length;
           }
         }
       }

--- a/lib/PullStream.js
+++ b/lib/PullStream.js
@@ -29,7 +29,9 @@ PullStream.prototype._write = function(chunk, e, cb) {
 PullStream.prototype.stream = function(eof, includeEof) {
   const p = Stream.PassThrough();
   let done;
-  const self= this;
+  const self = this;
+  const DATA_DESCRIPTOR_SIGNATURE = Buffer.alloc(4);
+  DATA_DESCRIPTOR_SIGNATURE.writeUInt32LE(0x08074b50, 0);
 
   function cb() {
     if (typeof self.cb === strFunction) {
@@ -37,6 +39,24 @@ PullStream.prototype.stream = function(eof, includeEof) {
       self.cb = undefined;
       return callback();
     }
+  }
+
+  function getDataDescriptorIndex(startIndex) {
+    const match = self.buffer.indexOf(DATA_DESCRIPTOR_SIGNATURE, startIndex);
+    if (match !== -1) {
+      if (self.buffer.length >= match + 12) {
+        const intBytes = self.buffer.slice(match + 8, match + 12); // 8 bytes after the data descriptor signature is the size of the compressed file.
+        const intValue = intBytes.readUInt16LE(0);
+
+        if (intValue === match) {
+          return match;
+        } else {
+          // Not a data descriptor signature for this buffer, so search after it.
+          return getDataDescriptorIndex(match + 1);
+        }
+      }
+    }
+    return -1;
   }
 
   function pull() {
@@ -48,7 +68,12 @@ PullStream.prototype.stream = function(eof, includeEof) {
         eof -= packet.length;
         done = done || !eof;
       } else {
-        let match = self.buffer.indexOf(eof);
+        let match = -1;
+        if (DATA_DESCRIPTOR_SIGNATURE.equals(eof)) {
+          match = getDataDescriptorIndex(0);
+        } else {
+          match = self.buffer.indexOf(eof);
+        }
         if (match !== -1) {
           // store signature match byte offset to allow us to reference
           // this for zip64 offset


### PR DESCRIPTION
### Why am I submitting this PR

Fixed a bug that caused Parse to fail when there is a zip in the zip, the zip has PK78, and the file in the zip also has PK78.

### ToDo

- [x]  Implement a fix to address the bug mentioned above.
- [ ] Add support for ZIP64 format handling (since compressedSize is represented in 8 bytes).
- [ ] Write tests to ensure the fix and the ZIP64 handling work as expected.