### PR TITLE
Support for progress option with extract

### DIFF
--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -164,6 +164,7 @@ module.exports = function centralDirectory(source, options) {
 
             if (entry.type == 'Directory') {
               await fs.ensureDir(extractPath);
+              if (opts.progress) opts.progress(entry);
               return;
             }
 
@@ -175,7 +176,10 @@ module.exports = function centralDirectory(source, options) {
               entry.stream(opts.password)
                 .on('error', reject)
                 .pipe(writer)
-                .on('close', resolve)
+                .on('close', () => {
+                  if (opts.progress) opts.progress(entry);
+                  resolve();
+                })
                 .on('error', reject);
             });
           }, { concurrency: opts.concurrency > 1 ? opts.concurrency : 1 });

--- a/test/open-extract.js
+++ b/test/open-extract.js
@@ -37,3 +37,29 @@ test("extract compressed archive with open.file.extract", function (t) {
       });
   });
 });
+
+test("extraction progress with open.file.extract", function (t) {
+  const archive = path.join(__dirname, '../testData/compressed-standard/archive.zip');
+
+  temp.mkdir('node-unzip-2', function (err, dirPath) {
+    if (err) {
+      throw err;
+    }
+    const progressEntries = new Set();
+    const progress = entry => {
+      progressEntries.add(entry.path);
+    };
+    unzip.Open.file(archive)
+      .then(function(d) {
+        return d.extract({path: dirPath, progress});
+      })
+      .then(async function() {
+        const root = path.resolve(__dirname, '../testData/compressed-standard/inflated');
+        // Check each entry exists
+        for (const p of progressEntries) {
+          t.ok(fs.pathExistsSync(path.join(root, p)), `progress entry does not exist: ${p}`);
+        }
+        t.end();
+      });
+  });
+});


### PR DESCRIPTION
Added `progress` to extract options to report once each (valid) `File` entry has been processed.
Also added test.