### PR TITLE
docs: Use 'close' event instead of 'finish' in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ async function main() {
       .stream()
       .pipe(fs.createWriteStream('firstFile'))
       .on('error',reject)
-      .on('finish',resolve)
+      .on('close',resolve)
   });
 }
 
@@ -129,7 +129,7 @@ async function main() {
       .stream()
       .pipe(fs.createWriteStream('firstFile'))
       .on('error',reject)
-      .on('finish',resolve)
+      .on('close',resolve)
   });
 }
 
@@ -299,7 +299,7 @@ fs.createReadStream('path/to/archive.zip')
       const size = entry.vars.uncompressedSize; // There is also compressedSize;
       if (fileName === "this IS the file I'm looking for") {
         entry.pipe(fs.createWriteStream('output/path'))
-          .on('finish',cb);
+          .on('close',cb);
       } else {
         entry.autodrain();
         cb();


### PR DESCRIPTION
This PR updates the getting-started documentation in the README.

Using the 'finish' event can be misleading as it only indicates that the source stream has ended, not that the data has been fully written to the destination. This is a common pitfall for new users of the library.

The 'close' event should be used to guarantee that the file has been completely written to disk.

This change updates the examples in the README to use the correct 'close' event, making the documentation more accurate and preventing potential issues for users.